### PR TITLE
[Bookcase] bookcase 코드 리팩토링 작업

### DIFF
--- a/src/components/bookcase/Cards.tsx
+++ b/src/components/bookcase/Cards.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { useEffect, useState } from "react";
 
 import { useGetBookInfo } from "../../core/api";
 import { BookcaseInfo, BookcasePathKey } from "../../types/bookcase";

--- a/src/components/bookcase/Cards.tsx
+++ b/src/components/bookcase/Cards.tsx
@@ -2,35 +2,18 @@ import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
 
 import { useGetBookInfo } from "../../core/api";
-import { BookcaseInfo } from "../../types/bookcase";
+import { BookcaseInfo, BookcasePathKey } from "../../types/bookcase";
 import { Loading } from "../common";
 import { AddBookCard, BookCard } from ".";
 import Empty from "./cardSection/Empty";
 
 interface CardsProps {
-  navIndex: number;
+  navIndex: BookcasePathKey;
 }
 
 export default function Cards(props: CardsProps) {
   const { navIndex } = props;
-  const [pathKey, setPathKey] = useState<string>("");
-  const { bookcaseInfo, isLoading, isError } = useGetBookInfo(pathKey);
-
-  useEffect(() => {
-    switch (navIndex) {
-      case 1:
-        setPathKey("/book/pre");
-        break;
-      case 2:
-        setPathKey("/book/peri");
-        break;
-      case 3:
-        setPathKey("/book/post");
-        break;
-      default:
-        setPathKey("/book");
-    }
-  }, [navIndex]);
+  const { bookcaseInfo, isLoading, isError } = useGetBookInfo(navIndex);
 
   if (isLoading) {
     return <Loading />;
@@ -45,7 +28,7 @@ export default function Cards(props: CardsProps) {
       <StSection>
         <AddBookCard />
         {bookcaseInfo.map((bookcaseInfo: BookcaseInfo, idx: number) => (
-          <BookCard key={idx} bookcaseInfo={bookcaseInfo} pathKey={pathKey} />
+          <BookCard key={idx} bookcaseInfo={bookcaseInfo} navIndex={navIndex} />
         ))}
       </StSection>
     );

--- a/src/components/bookcase/Navigation.tsx
+++ b/src/components/bookcase/Navigation.tsx
@@ -3,9 +3,11 @@ import styled from "@emotion/styled";
 import { useViewportScroll } from "framer-motion";
 import { useEffect, useState } from "react";
 
+import { BookcasePathKey } from "../../types/bookcase";
+
 interface NavigationProps {
-  navIndex: number;
-  onChangeNavIndex: (idx: number) => void;
+  navIndex: BookcasePathKey;
+  onChangeNavIndex: (idx: BookcasePathKey) => void;
 }
 export default function Navigation(props: NavigationProps) {
   const { navIndex, onChangeNavIndex } = props;
@@ -13,6 +15,22 @@ export default function Navigation(props: NavigationProps) {
   const [isScroll, setIsScroll] = useState<boolean>(false);
   const { scrollY } = useViewportScroll();
   const MAIN_HEADER_HEIGHT = 109;
+
+  let navUnderbarIndex = 0;
+
+  switch (navIndex) {
+    case "/book/pre":
+      navUnderbarIndex = 1;
+      break;
+    case "/book/peri":
+      navUnderbarIndex = 2;
+      break;
+    case "/book/post":
+      navUnderbarIndex = 3;
+      break;
+    default:
+      navUnderbarIndex = 0;
+  }
 
   useEffect(() => {
     scrollY.onChange(() => {
@@ -31,13 +49,13 @@ export default function Navigation(props: NavigationProps) {
   return (
     <StNav isscroll={isScroll}>
       <StUl>
-        <StList onClick={() => onChangeNavIndex(0)}>전체</StList>
-        <StList onClick={() => onChangeNavIndex(1)}>독서 전</StList>
-        <StList onClick={() => onChangeNavIndex(2)}>독서 중</StList>
-        <StList onClick={() => onChangeNavIndex(3)}>독서 완료</StList>
+        <StList onClick={() => onChangeNavIndex("/book")}>전체</StList>
+        <StList onClick={() => onChangeNavIndex("/book/pre")}>독서 전</StList>
+        <StList onClick={() => onChangeNavIndex("/book/peri")}>독서 중</StList>
+        <StList onClick={() => onChangeNavIndex("/book/post")}>독서 완료</StList>
       </StUl>
       <StBottomLine>
-        <StOrangLine index={navIndex} />
+        <StOrangLine index={navUnderbarIndex} />
       </StBottomLine>
     </StNav>
   );

--- a/src/components/bookcase/cardSection/BookCard.tsx
+++ b/src/components/bookcase/cardSection/BookCard.tsx
@@ -98,9 +98,10 @@ const StCardWrapper = styled.div`
   &:hover {
     background-color: ${({ theme }) => theme.colors.orange200};
     cursor: pointer;
-  }
-  & > svg {
-    display: block;
+
+    & > svg {
+      display: block;
+    }
   }
 `;
 

--- a/src/components/bookcase/cardSection/BookCard.tsx
+++ b/src/components/bookcase/cardSection/BookCard.tsx
@@ -25,8 +25,16 @@ export default function BookCard(props: BookCardProps) {
   const setNavigatingBookInfo = useSetRecoilState(navigatingBookInfoState);
   const router = useRouter();
 
-  const reviewUrl: BookNoteUrlPath =
-    reviewSt === 2 ? "/book-note" : reviewSt === 3 ? "/book-note/peri" : "/book-note/detail-book-note";
+  let reviewUrl: BookNoteUrlPath = "/book-note"; // reviewSt === 2
+
+  switch (reviewSt) {
+    case 3:
+      reviewUrl = "/book-note/peri";
+      break;
+    case 4:
+      reviewUrl = "/book-note/detail-book-note";
+      break;
+  }
 
   // 홈에 대한 예외 처리
   const handleTogglePopUp = () => {

--- a/src/components/bookcase/cardSection/BookCard.tsx
+++ b/src/components/bookcase/cardSection/BookCard.tsx
@@ -7,6 +7,7 @@ import { useRecoilValue, useSetRecoilState } from "recoil";
 import { IcBin } from "../../../../public/assets/icons";
 import { isLoginState, navigatingBookInfoState } from "../../../core/atom";
 import { BookcaseInfo, BookcasePathKey } from "../../../types/bookcase";
+import { BookNoteUrlPath } from "../../../types/bookNote";
 import { PopUpDelete } from "../../common";
 import { StBookCardImgWrapper } from "../../common/styled/Img";
 
@@ -24,7 +25,8 @@ export default function BookCard(props: BookCardProps) {
   const setNavigatingBookInfo = useSetRecoilState(navigatingBookInfoState);
   const router = useRouter();
 
-  const reviewUrl = reviewSt === 2 ? "/book-note" : reviewSt === 3 ? "/book-note/peri" : "/book-note/detail-book-note";
+  const reviewUrl: BookNoteUrlPath =
+    reviewSt === 2 ? "/book-note" : reviewSt === 3 ? "/book-note/peri" : "/book-note/detail-book-note";
 
   // 홈에 대한 예외 처리
   const handleTogglePopUp = () => {

--- a/src/components/bookcase/cardSection/BookCard.tsx
+++ b/src/components/bookcase/cardSection/BookCard.tsx
@@ -6,17 +6,17 @@ import { useRecoilValue, useSetRecoilState } from "recoil";
 
 import { IcBin } from "../../../../public/assets/icons";
 import { isLoginState, navigatingBookInfoState } from "../../../core/atom";
-import { BookcaseInfo } from "../../../types/bookcase";
+import { BookcaseInfo, BookcasePathKey } from "../../../types/bookcase";
 import { PopUpDelete } from "../../common";
 import { StBookCardImgWrapper } from "../../common/styled/Img";
 
 interface BookCardProps {
   bookcaseInfo: BookcaseInfo;
-  pathKey: string;
+  navIndex: BookcasePathKey;
 }
 
 export default function BookCard(props: BookCardProps) {
-  const { bookcaseInfo, pathKey } = props;
+  const { bookcaseInfo, navIndex } = props;
   const { author, reviewId, thumbnail, title, reviewSt } = bookcaseInfo;
 
   const [isPopUp, setIsPopUp] = useState(false);
@@ -26,25 +26,6 @@ export default function BookCard(props: BookCardProps) {
 
   const reviewUrl = reviewSt === 2 ? "/book-note" : reviewSt === 3 ? "/book-note/peri" : "/book-note/detail-book-note";
 
-  let fromSt = 0;
-
-  switch (pathKey) {
-    case "/book":
-      fromSt = 0;
-      break;
-    case "/book/pre":
-      fromSt = 1;
-      break;
-    case "/book/peri":
-      fromSt = 2;
-      break;
-    case "/book/post":
-      fromSt = 3;
-      break;
-    default:
-      break;
-  }
-
   // 홈에 대한 예외 처리
   const handleTogglePopUp = () => {
     setIsPopUp((isPopUp) => !isPopUp);
@@ -53,7 +34,7 @@ export default function BookCard(props: BookCardProps) {
   const moveBookNoteHandler = () => {
     if (!isLogin) return;
 
-    const tempNavigatingBookInfo = { reviewId, title, fromUrl: router.pathname, fromSt };
+    const tempNavigatingBookInfo = { reviewId, title, fromUrl: router.pathname, fromSt: navIndex };
 
     setNavigatingBookInfo(tempNavigatingBookInfo);
     router.push(reviewUrl);
@@ -85,7 +66,7 @@ export default function BookCard(props: BookCardProps) {
         </StTextWrapper>
       </StBookCard>
       <StIcBin onClick={handleTogglePopUp} />
-      {isPopUp && <PopUpDelete onTogglePopUp={handleTogglePopUp} pathKey={pathKey} reviewId={reviewId} />}
+      {isPopUp && <PopUpDelete onTogglePopUp={handleTogglePopUp} navIndex={navIndex} reviewId={reviewId} />}
     </StCardWrapper>
   );
 }

--- a/src/components/bookcase/cardSection/Empty.tsx
+++ b/src/components/bookcase/cardSection/Empty.tsx
@@ -3,29 +3,30 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { ImgEmptyBook } from "../../../../public/assets/images";
+import { BookcasePathKey } from "../../../types/bookcase";
 import { DefaultButton } from "../../common/styled/Button";
 
 interface EmptyProps {
-  navIndex: number;
+  navIndex: BookcasePathKey;
 }
 
 export default function Empty(props: EmptyProps) {
   const { navIndex } = props;
 
-  const allOrPre = navIndex <= 1;
+  const isNavIndexDefaultOrPre = navIndex === "/book" || navIndex === "/book/pre";
 
   return (
     <StArticle>
       <StImgWrapper>
         <Image src={ImgEmptyBook} alt="빈 폴더 이미지" />
       </StImgWrapper>
-      <StH3>{allOrPre ? "아직 읽은 책이 없어요." : "이 단계의 책이 없어요."}</StH3>
+      <StH3>{isNavIndexDefaultOrPre ? "아직 읽은 책이 없어요." : "이 단계의 책이 없어요."}</StH3>
 
       <StParagraph>
         북스테어즈만의 독서법을 통해
         <br /> 지식을 얻고 독서의 매력을 느껴보세요
       </StParagraph>
-      {allOrPre && (
+      {isNavIndexDefaultOrPre && (
         <Link href="/bookcase/add-book" passHref>
           <StAddBookBtn>+ 책 추가</StAddBookBtn>
         </Link>

--- a/src/components/common/PopUpDelete.tsx
+++ b/src/components/common/PopUpDelete.tsx
@@ -6,16 +6,17 @@ import { useSWRConfig } from "swr";
 import { ImgDeletePopUp } from "../../../public/assets/images";
 import { deleteData } from "../../core/api";
 import LocalStorage from "../../core/localStorage";
+import { BookcasePathKey } from "../../types/bookcase";
 import { StBtnCancel, StBtnDelete, StBtnWrapper, StDetail, StPopUp, StPopUpWrapper, StQuestion } from "./styled/PopUp";
 
 interface PopUpDeleteProps {
   onTogglePopUp: () => void;
-  pathKey: string;
+  navIndex: BookcasePathKey;
   reviewId: string;
 }
 
 export default function PopUpDelete(props: PopUpDeleteProps) {
-  const { onTogglePopUp, pathKey, reviewId } = props;
+  const { onTogglePopUp, navIndex, reviewId } = props;
 
   const { mutate } = useSWRConfig();
   const router = useRouter();
@@ -26,7 +27,7 @@ export default function PopUpDelete(props: PopUpDeleteProps) {
     await deleteData(`/review/${reviewId}`, userToken);
 
     onTogglePopUp();
-    mutate(pathKey);
+    mutate(navIndex);
 
     if (router.pathname === "/book-note/detail-book-note") {
       router.push("/main/bookcase");

--- a/src/components/myPage/BookComment.tsx
+++ b/src/components/myPage/BookComment.tsx
@@ -6,19 +6,23 @@ interface BooksNumProps {
 
 export default function BookComment(props: BooksNumProps) {
   const { reviewCount } = props;
-  const nowComment = "지금까지";
+  const readComment =
+    reviewCount < 10 ? (
+      <>
+        <StNowcomment>지금까지</StNowcomment>
+        <StReadcomment>권 책을 읽었어요</StReadcomment>
+      </>
+    ) : (
+      <StReadcomment>
+        권의 {reviewCount < 100 && "\n"}
+        책을 읽었어요
+      </StReadcomment>
+    );
 
   return (
     <>
       <StBooksNum>{reviewCount}</StBooksNum>
-      <StWrapper>
-        {reviewCount < 10 && <StNowcomment>{nowComment}</StNowcomment>}
-        <StReadcomment>
-          권{reviewCount < 10 ? <>&nbsp;</> : <>의&nbsp;</>}
-          {10 <= reviewCount && reviewCount < 100 && <br />}
-          책을 읽었어요
-        </StReadcomment>
-      </StWrapper>
+      <StWrapper>{readComment}</StWrapper>
     </>
   );
 }

--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -15,7 +15,7 @@ export const navigatingBookInfoState = atom<NavigatingBookInfoState>({
     reviewId: "-1",
     title: "",
     fromUrl: "",
-    fromSt: 0,
+    fromSt: "/book",
   },
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/pages/bookcase/index.tsx
+++ b/src/pages/bookcase/index.tsx
@@ -6,20 +6,21 @@ import Navigation from "../../components/bookcase/Navigation";
 import { Loading } from "../../components/common";
 import { MainLayout } from "../../components/layout";
 import { isLoginState, navigatingBookInfoState } from "../../core/atom";
+import { BookcasePathKey } from "../../types/bookcase";
 // import useCheckLoginState from "../../util/hooks/useCheckLoginState";
 
 export default function Bookcase() {
   const navigatingBookInfo = useRecoilValue(navigatingBookInfoState);
   const { fromSt } = navigatingBookInfo;
 
-  const [navIndex, setNavIndex] = useState<number>(fromSt);
+  const [navIndex, setNavIndex] = useState<BookcasePathKey>(fromSt);
   // const { isLogin, isLoginLoading } = useCheckLoginState();
   const isLogin = useRecoilValue(isLoginState);
   const isLoginLoading = false;
   // 여기까지 임시 코드
   const setIsLogin = useSetRecoilState(isLoginState);
 
-  const handleChangeNavIndex = (idx: number) => {
+  const handleChangeNavIndex = (idx: BookcasePathKey) => {
     setNavIndex(idx);
   };
 

--- a/src/pages/bookcase/index.tsx
+++ b/src/pages/bookcase/index.tsx
@@ -25,11 +25,7 @@ export default function Bookcase() {
   };
 
   useEffect(() => {
-    if (isLogin) {
-      setIsLogin(true);
-    } else {
-      setIsLogin(false);
-    }
+    setIsLogin(isLogin);
   }, [isLogin]);
 
   return (

--- a/src/types/bookNote.ts
+++ b/src/types/bookNote.ts
@@ -19,13 +19,13 @@ export interface PeriNoteTreeNode {
 
 export interface PeriNoteData {
   answerThree: PeriNoteTreeNode;
-  reviewSt: number;
+  reviewSt: 2 | 3 | 4;
 }
 
 export interface PreNoteData {
   answerOne: string;
   answerTwo: string;
   questionList: string[];
-  reviewSt: number;
+  reviewSt: 2 | 3 | 4;
   finishSt?: boolean;
 }

--- a/src/types/bookNote.ts
+++ b/src/types/bookNote.ts
@@ -1,3 +1,11 @@
+const bookNoteUrlPath = {
+  default: "/book-note",
+  peri: "/book-note/peri",
+  detail: "/book-note/detail-book-note",
+} as const;
+
+export type BookNoteUrlPath = typeof bookNoteUrlPath[keyof typeof bookNoteUrlPath];
+
 export interface PeriNoteTreeNode {
   type: string;
   content: string;

--- a/src/types/bookcase.ts
+++ b/src/types/bookcase.ts
@@ -12,3 +12,12 @@ export interface BookcaseInfo {
   thumbnail: string;
   title: string;
 }
+
+const bookcasePathKey = {
+  default: "/",
+  Pre: "/PRE",
+  Peri: "/PERI",
+  Post: "/POST",
+};
+
+export type BookcasePathKey = typeof bookcasePathKey[keyof typeof bookcasePathKey];

--- a/src/types/bookcase.ts
+++ b/src/types/bookcase.ts
@@ -15,9 +15,9 @@ export interface BookcaseInfo {
 
 const bookcasePathKey = {
   default: "/book",
-  Pre: "/book/pre",
-  Peri: "/book/peri",
-  Post: "/book/post",
+  pre: "/book/pre",
+  peri: "/book/peri",
+  post: "/book/post",
 };
 
 export type BookcasePathKey = typeof bookcasePathKey[keyof typeof bookcasePathKey];

--- a/src/types/bookcase.ts
+++ b/src/types/bookcase.ts
@@ -14,10 +14,10 @@ export interface BookcaseInfo {
 }
 
 const bookcasePathKey = {
-  default: "/",
-  Pre: "/PRE",
-  Peri: "/PERI",
-  Post: "/POST",
+  default: "/book",
+  Pre: "/book/pre",
+  Peri: "/book/peri",
+  Post: "/book/post",
 };
 
 export type BookcasePathKey = typeof bookcasePathKey[keyof typeof bookcasePathKey];

--- a/src/types/bookcase.ts
+++ b/src/types/bookcase.ts
@@ -17,7 +17,7 @@ export interface NavigatingBookInfoState {
 export interface BookcaseInfo {
   author: string[];
   reviewId: string;
-  reviewSt?: number;
+  reviewSt?: 2 | 3 | 4;
   thumbnail: string;
   title: string;
 }

--- a/src/types/bookcase.ts
+++ b/src/types/bookcase.ts
@@ -1,8 +1,17 @@
+const bookcasePathKey = {
+  default: "/book",
+  pre: "/book/pre",
+  peri: "/book/peri",
+  post: "/book/post",
+} as const;
+
+export type BookcasePathKey = typeof bookcasePathKey[keyof typeof bookcasePathKey];
+
 export interface NavigatingBookInfoState {
   reviewId: string;
   title: string;
   fromUrl: string;
-  fromSt: number;
+  fromSt: BookcasePathKey;
 }
 
 export interface BookcaseInfo {
@@ -12,12 +21,3 @@ export interface BookcaseInfo {
   thumbnail: string;
   title: string;
 }
-
-const bookcasePathKey = {
-  default: "/book",
-  pre: "/book/pre",
-  peri: "/book/peri",
-  post: "/book/post",
-};
-
-export type BookcasePathKey = typeof bookcasePathKey[keyof typeof bookcasePathKey];


### PR DESCRIPTION
## 📌 나 이런 거 했어요

<!-- 구현 기능 명세서 ~ 소요 시간 등등 -->

- [지난 main 마이그레이션 PR](https://github.com/TeamBookTez/nextjs-book-stairs/pull/19)에 이어서, bookcase에 중점적으로 리팩토링 작업을 진행하였습니다!

### 주요 작업

- `bookComment` 컴포넌트 변수를 추가하여 가독성이 떨어지는 jsx를 보완하였습니다
- `BookcasePathKey` 및 `BookNoteUrlPath` 타입을 추가하여, string 으로 지정해주었던 타입을 보다 더 명확히 잡아주었습니다.
enum 타입을 활용하려다, enum 타입을 그대로 사용할 경우 트리쉐이킹이 되지 않는 문제가 대두된다는 아티클을 보아 const 변수를 활용하여 구현하였습니다 [(관련한 SNUPI 아티클)](https://snupi.tistory.com/202)
const로 readonly 변수를 지정해준 후, 이를 사용해 타입을 지정하여 유니온 타입으로써 사용하는 방식입니다
```typescript
const bookcasePathKey = {
  default: "/book",
  pre: "/book/pre",
  peri: "/book/peri",
  post: "/book/post",
} as const;

export type BookcasePathKey = typeof bookcasePathKey[keyof typeof bookcasePathKey];
```
- `reviewSt` 변수 타입을 2, 3, 4 (독서 전, 중, 후)로 지정해주었습니다!

<br />

## 📌 나 이런 거 알게 되었어요

<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->

- const 를 이용한 유니온 타입 활용 !
