### PR TITLE
Feature/login api

### DIFF
--- a/components/bookcase/Cards.tsx
+++ b/components/bookcase/Cards.tsx
@@ -1,46 +1,32 @@
 import styled from "@emotion/styled";
 
-import { useGetBookInfo } from "../../core/api";
 import { BookcaseInfo, BookcasePathKey } from "../../types/bookcase";
 import { Loading } from "../common";
-import { AddBookCard, BookCard } from ".";
-import Empty from "./cardSection/Empty";
+import { AddBookCard, BookCard, NoCards } from ".";
+
+interface BookcaseFetchStatus {
+  bookcaseInfo: BookcaseInfo[];
+  isLoading: boolean;
+  isError: boolean;
+}
 
 interface CardsProps {
   navIndex: BookcasePathKey;
+  bookcaseInfo: BookcaseInfo[];
 }
 
 export default function Cards(props: CardsProps) {
-  const { navIndex } = props;
-  const { bookcaseInfo, isLoading, isError } = useGetBookInfo(navIndex);
+  const { navIndex, bookcaseInfo } = props;
 
-  if (isLoading) {
-    return <Loading />;
-  } else if (!bookcaseInfo || isError || bookcaseInfo.length === 0) {
-    return (
-      <StDefaultSection>
-        <Empty navIndex={navIndex} />
-      </StDefaultSection>
-    );
-  } else {
-    return (
-      <StSection>
-        <AddBookCard />
-        {bookcaseInfo.map((bookcaseInfo: BookcaseInfo, idx: number) => (
-          <BookCard key={idx} bookcaseInfo={bookcaseInfo} navIndex={navIndex} />
-        ))}
-      </StSection>
-    );
-  }
+  return (
+    <StSection>
+      <AddBookCard />
+      {bookcaseInfo.map((bookcaseInfo: BookcaseInfo, idx: number) => (
+        <BookCard key={idx} bookcaseInfo={bookcaseInfo} navIndex={navIndex} />
+      ))}
+    </StSection>
+  );
 }
-
-const StDefaultSection = styled.section`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  height: calc(100vh - 19.7rem);
-`;
 
 const StSection = styled.section`
   display: flex;

--- a/components/bookcase/NoCards.tsx
+++ b/components/bookcase/NoCards.tsx
@@ -1,3 +1,25 @@
-export default function NoCards() {
-  return <div>NoCards</div>;
+import styled from "@emotion/styled";
+
+import { BookcasePathKey } from "../../types/bookcase";
+import Empty from "./cardSection/Empty";
+
+interface NoCardsProps {
+  navIndex: BookcasePathKey;
 }
+export default function NoCards(props: NoCardsProps) {
+  const { navIndex } = props;
+
+  return (
+    <StDefaultSection>
+      <Empty navIndex={navIndex} />
+    </StDefaultSection>
+  );
+}
+
+const StDefaultSection = styled.section`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  height: calc(100vh - 19.7rem);
+`;

--- a/components/bookcase/cardSection/BookCard.tsx
+++ b/components/bookcase/cardSection/BookCard.tsx
@@ -45,7 +45,7 @@ export default function BookCard(props: BookCardProps) {
       <StBookCard onClick={moveBookNoteHandler}>
         <StImgWrapper>
           <StBookCardImgWrapper>
-            <Image src={thumbnail} alt={`도서 ${title}의 이미지`} />
+            <Image width={205} height={300} src={thumbnail} alt={`도서 ${title}의 이미지`} />
           </StBookCardImgWrapper>
         </StImgWrapper>
         <StTextWrapper>

--- a/components/main/RecentBooks.tsx
+++ b/components/main/RecentBooks.tsx
@@ -1,14 +1,15 @@
 import styled from "@emotion/styled";
 import Link from "next/link";
-import { useEffect, useState } from "react";
 import { useMediaQuery } from "react-responsive";
 
 import { useGetBookInfo } from "../../core/api";
+import { BookcaseInfo } from "../../types/bookcase";
+import { BookCard } from "../bookcase";
 import { Empty, Loading } from "../common";
 
 export default function RecentBooks() {
-  const [isAnyBooks, setIsAnyBooks] = useState<boolean>(false);
   const { bookcaseInfo, isLoading } = useGetBookInfo("/book");
+  const isNotEmpty = bookcaseInfo !== undefined && bookcaseInfo?.length > 0;
 
   const isWideDesktopScreen = useMediaQuery({
     query: "(min-width: 1920px) ",
@@ -18,42 +19,31 @@ export default function RecentBooks() {
   });
   const cntRecentBooks = isWideWideDesktopScreen ? 8 : isWideDesktopScreen ? 6 : 5;
 
-  useEffect(() => {
-    if (bookcaseInfo && bookcaseInfo?.length) {
-      setIsAnyBooks(true);
-    } else {
-      setIsAnyBooks(false);
-    }
-  }, [bookcaseInfo]);
-
   if (isLoading) {
     return <Loading />;
   } else {
     return (
       <section>
-        <>
-          <StHeader>
-            <StHeading3>최근 작성한 북노트</StHeading3>
-            {isAnyBooks && (
-              <Link href="/main/bookcase">
-                <StLink>전체보기</StLink>
-              </Link>
-            )}
-          </StHeader>
-          <StBookWrapper isdefault={!isAnyBooks}>
-            {isAnyBooks ? (
-              bookcaseInfo &&
-              bookcaseInfo
-                .slice(0, cntRecentBooks)
-                .map(
-                  (tempInfo, idx) =>
-                    /*<BookCard key={idx 말고 id 값} bookcaseInfo={tempInfo} pathKey="/book" />*/ "북카드",
-                )
-            ) : (
-              <Empty />
-            )}
-          </StBookWrapper>
-        </>
+        <StHeader>
+          <StHeading3>최근 작성한 북노트</StHeading3>
+          {isNotEmpty && (
+            <Link href="/main/bookcase">
+              <StLink>전체보기</StLink>
+            </Link>
+          )}
+        </StHeader>
+        <StBookWrapper isdefault={!isNotEmpty}>
+          {isNotEmpty ? (
+            bookcaseInfo &&
+            bookcaseInfo
+              .slice(0, cntRecentBooks)
+              .map((bookInfo: BookcaseInfo) => (
+                <BookCard key={bookInfo.reviewId} bookcaseInfo={bookInfo} navIndex={"/main"} />
+              ))
+          ) : (
+            <Empty />
+          )}
+        </StBookWrapper>
       </section>
     );
   }

--- a/core/api.ts
+++ b/core/api.ts
@@ -39,12 +39,15 @@ export const deleteData = (key: string) => {
 };
 
 export function useGetBookInfo(key: string) {
-  const urlKey = key === "/main" ? "" : key;
-  const { data, isValidating } = useSWR<Response<BookcaseInfo[]>>(urlKey, baseInstance.get);
+  const urlKey = key === "/main" ? "/book" : key;
+  const { data, error } = useSWR<Response<{ books: BookcaseInfo[] }>>(urlKey, baseInstance.get);
+
+  console.log(data, error);
 
   return {
-    bookcaseInfo: data?.data,
-    isLoading: isValidating,
+    bookcaseInfo: data?.data.books,
+    isLoading: !error && !data,
+    isError: error,
   };
 }
 

--- a/core/axios.ts
+++ b/core/axios.ts
@@ -9,8 +9,16 @@ const baseInstance = axios.create({
   baseURL: `${BASE_URL}`,
   headers: {
     "Content-Type": "application/json",
-    Authorization: LocalStorage.getItem("booktez-token"),
   },
+});
+
+baseInstance.interceptors.request.use((config) => {
+  const headers = {
+    ...config.headers,
+    Authorization: LocalStorage.getItem("booktez-token"),
+  };
+
+  return { ...config, headers };
 });
 
 baseInstance.interceptors.response.use(

--- a/pages/bookcase/index.tsx
+++ b/pages/bookcase/index.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
 import { useRecoilValue } from "recoil";
 
+import { NoCards } from "../../components/bookcase";
 import Cards from "../../components/bookcase/Cards";
 import Navigation from "../../components/bookcase/Navigation";
 import { Loading } from "../../components/common";
 import { MainLayout } from "../../components/layout";
 import { MainHeader } from "../../components/main";
+import { useGetBookInfo } from "../../core/api";
 import { navigatingBookInfoState } from "../../core/atom";
 import { BookcasePathKey } from "../../types/bookcase";
 import useUser from "../../util/hooks/useUser";
@@ -16,6 +18,7 @@ export default function Bookcase() {
 
   const { isLogin, isLoginLoading } = useUser();
   const [navIndex, setNavIndex] = useState<BookcasePathKey>(fromSt);
+  const { bookcaseInfo, isLoading, isError } = useGetBookInfo(navIndex);
 
   const handleChangeNavIndex = (idx: BookcasePathKey) => {
     setNavIndex(idx);
@@ -30,7 +33,13 @@ export default function Bookcase() {
       ) : (
         <>
           <Navigation navIndex={navIndex} onChangeNavIndex={handleChangeNavIndex} />
-          <Cards navIndex={navIndex} />
+          {isLoading ? (
+            <Loading />
+          ) : !bookcaseInfo || isError || bookcaseInfo.length === 0 ? (
+            <NoCards navIndex={navIndex} />
+          ) : (
+            <Cards navIndex={navIndex} bookcaseInfo={bookcaseInfo} />
+          )}
         </>
       )}
     </MainLayout>

--- a/util/hooks/useUserInfo.ts
+++ b/util/hooks/useUserInfo.ts
@@ -20,11 +20,10 @@ interface MyInfo {
 }
 
 export default function useUserInfo() {
-  const { data, error } = useSWR<Response<MyInfo>>("/user/myInfo", baseInstance.get);
+  const { data, isValidating } = useSWR<Response<MyInfo>>("/user/myInfo", baseInstance.get);
 
   return {
     userInfo: data?.data,
-    isLoading: !error && !data?.data,
-    isError: error,
+    isLoading: isValidating,
   };
 }

--- a/util/hooks/useUserInfo.ts
+++ b/util/hooks/useUserInfo.ts
@@ -1,11 +1,13 @@
 /*
-마지막 편집자: 22-06-13 soryeongk
+마지막 편집자: 22-06-16 soryeongk
 변경사항 및 참고:
-  - 
+  - 지난 번 SWR 정리한 것을 보면서 isValidating이나 error를 받는 것이 코드 짤때는 편하지만 불필요한 렌더링을 야기한다는 것을 떠올렸습니다!
+    그래서 isValidating을 받기 보다는 공식문서에서 자주 사용하는대로 data, error만으로 로딩을 판변하려 합니다 :) 안그럼 3~4번은 기본 렌더링되어서,,
+    데이터 변경이 없으면 리소스 낭비가 그리 크지 않은데, 그래도 신경쓰여서! 뜰람뜰
+    (참고: https://www.notion.so/SWR-9bf677a0acc74b4a8f8d0964b2213975#1b0d8ba3e4a149c587c3347cfa68f755)
     
 고민점:
   - revalidate option으로 focusing할 때마다 업데이트하는 것은 막을까 싶습니다. 마이페이지의 내용이 자주 업데이트되는 것은 아니라서..! 요청이 계속 오가는 것이 마음에 걸립니다.
-  - useSWR에서 어떤건 isValidating을 넣고 뭐는 error만 넣는 등 통일이 안되어있어서 제대로 된 기준을 좀 확립해보겠습니답
 */
 import useSWR from "swr";
 


### PR DESCRIPTION
## 📌 나 이런 거 했어요

<!-- 구현 기능 명세서 ~ 소요 시간 등등 -->

- 로그인 여부를 확인하는 useUser를 고쳤습니다. 기존에는 새로고침을 해야 적용되었는데, 이제는 페이지 이동마다 가능합니다. 약간 끊김과 화면 전환이 남은 것 같아 build해보면서 고쳐보려합니다.
- axios interceptors의 영향으로 swr에서 기본적으로 받아오는 error는 undefined가 됩니다.. 대신 우리 서버에서 예쁘게 정리해서 보내주는 error data는 data에 잘 담깁니다. **결론: useSWR을 쓸 때 `{ data }`에서 성공/실패 response를 모두 받아볼 수 있다! SWR의 error는 undefined**

<br />

## 📌 나 이런 거 알게 되었어요

<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->

- 진짜 바보같게도 interceptors를 잘 설정하면 쉽게 해결할 수 있는 것이었습니다. 내가 그냥 잘못 설정한거였어요.... 해당 내용은 discussions에 잘 기재해두겠습니다. #29 

<br />

## 📌 나 이런 거 궁금해요

<!-- 작은 거라도 조아  -->

- 있을리가 ㅋ
