### PR TITLE
Feature refactor booknote kkm

### DIFF
--- a/components/bookNote/periNote/ChildQANode.tsx
+++ b/components/bookNote/periNote/ChildQANode.tsx
@@ -20,27 +20,27 @@ import { StMoreIcon } from "../../common/styled/Icon";
 import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 
 interface ChildQANodeProps {
-  path: number[];
+  pathStack: number[];
   index: number;
   node: PeriNoteTreeNode;
-  onAddChild: (path: number[], index?: number) => void;
-  onSetContent: (value: string, path: number[]) => void;
-  onDeleteChild: (path: number[]) => void;
+  onAddChild: (pathStack: number[], index?: number) => void;
+  onSetContent: (value: string, pathStack: number[]) => void;
+  onDeleteChild: (pathStack: number[]) => void;
   formController: FormController;
 }
 export default function ChildQANode(props: ChildQANodeProps) {
-  const { path, index, node, onAddChild, onSetContent, onDeleteChild, formController } = props;
-  const { urgentQuery, setUrgentQuery } = useUpdatePeriNote(node.content, path, onSetContent);
+  const { pathStack, index, node, onAddChild, onSetContent, onDeleteChild, formController } = props;
+  const { urgentQuery, setUrgentQuery } = useUpdatePeriNote(node.content, pathStack, onSetContent);
   const isQuestion = node.type === "question";
-  const inputKey = `${path.join(",")}`;
-  const labelColor = labelColorList[(path.length - 1) % 10];
+  const inputKey = `${pathStack.join(",")}`;
+  const labelColor = labelColorList[(pathStack.length - 1) % 10];
 
   const addChildByEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       // 꼬리질문과 답변은 자신의 아래에 추가하는 것이 아닌 자신의 부모의 children에 추가해야함
-      if (isQuestion) onAddChild(path.slice(0, -1));
-      else onAddChild(path.slice(0, -1), index + 1);
+      if (isQuestion) onAddChild(pathStack.slice(0, -1));
+      else onAddChild(pathStack.slice(0, -1), index + 1);
     }
   };
 
@@ -52,11 +52,11 @@ export default function ChildQANode(props: ChildQANodeProps) {
 
   useEffect(() => {
     // 마지막 생성된 컴포넌트에 focusing
-    path.length <= 10 && formController.setFocus(inputKey);
+    pathStack.length <= 10 && formController.setFocus(inputKey);
   }, [formController.setFocus]);
 
   // 후에 레이아웃 문제에 대비하여 4뎁스 제한
-  if (path.length > 10) return null;
+  if (pathStack.length > 10) return null;
 
   return (
     <>
@@ -77,18 +77,18 @@ export default function ChildQANode(props: ChildQANodeProps) {
             onKeyPress={addChildByEnter}
           />
           {isQuestion && (
-            <StAddAnswerButton type="button" onClick={() => onAddChild(path, index + 1)}>
+            <StAddAnswerButton type="button" onClick={() => onAddChild(pathStack, index + 1)}>
               답변
             </StAddAnswerButton>
           )}
           <StMore className="icn_more" />
           <StMenuWrapper>
-            {!isQuestion && path.length < 10 && (
-              <StMenuBtn type="button" onClick={() => onAddChild(path)}>
+            {!isQuestion && pathStack.length < 10 && (
+              <StMenuBtn type="button" onClick={() => onAddChild(pathStack)}>
                 꼬리질문 추가
               </StMenuBtn>
             )}
-            <StMenuBtn type="button" onClick={() => onDeleteChild(path)}>
+            <StMenuBtn type="button" onClick={() => onDeleteChild(pathStack)}>
               삭제
             </StMenuBtn>
           </StMenuWrapper>
@@ -99,7 +99,7 @@ export default function ChildQANode(props: ChildQANodeProps) {
           node.children.map((node, i) => (
             <ChildQANode
               key={`childQANode-${i}`}
-              path={[...path, i]}
+              pathStack={[...pathStack, i]}
               index={i}
               node={node}
               onAddChild={onAddChild}

--- a/components/bookNote/periNote/ChildQANode.tsx
+++ b/components/bookNote/periNote/ChildQANode.tsx
@@ -22,16 +22,16 @@ import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 interface ChildQANodeProps {
   pathStack: number[];
   index: number;
-  node: PeriNoteTreeNode;
+  childQANode: PeriNoteTreeNode;
   onAddChild: (pathStack: number[], index?: number) => void;
   onSetContent: (value: string, pathStack: number[]) => void;
   onDeleteChild: (pathStack: number[]) => void;
   formController: FormController;
 }
 export default function ChildQANode(props: ChildQANodeProps) {
-  const { pathStack, index, node, onAddChild, onSetContent, onDeleteChild, formController } = props;
-  const { urgentQuery, setUrgentQuery } = useUpdatePeriNote(node.content, pathStack, onSetContent);
-  const isQuestion = node.type === "question";
+  const { pathStack, index, childQANode, onAddChild, onSetContent, onDeleteChild, formController } = props;
+  const { urgentQuery, setUrgentQuery } = useUpdatePeriNote(childQANode.content, pathStack, onSetContent);
+  const isQuestion = childQANode.type === "question";
   const inputKey = `${pathStack.join(",")}`;
   const labelColor = labelColorList[(pathStack.length - 1) % 10];
 
@@ -70,7 +70,7 @@ export default function ChildQANode(props: ChildQANodeProps) {
         <StInputWrapper isquestion={isQuestion}>
           <StInput
             {...formController.register(inputKey)}
-            defaultValue={node.content}
+            defaultValue={childQANode.content}
             value={urgentQuery}
             placeholder={`${isQuestion ? "질문" : "답변"}을 입력해주세요.`}
             onChange={handleContent}
@@ -95,13 +95,13 @@ export default function ChildQANode(props: ChildQANodeProps) {
         </StInputWrapper>
       </StFieldset>
       <StFieldWrapper isquestion={isQuestion}>
-        {node.children &&
-          node.children.map((node, i) => (
+        {childQANode.children &&
+          childQANode.children.map((childQANode, i) => (
             <ChildQANode
               key={`childQANode-${i}`}
               pathStack={[...pathStack, i]}
               index={i}
-              node={node}
+              childQANode={childQANode}
               onAddChild={onAddChild}
               onDeleteChild={onDeleteChild}
               onSetContent={onSetContent}

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -48,11 +48,8 @@ export default function PeriNote(props: PeriNoteProps) {
   const handleAddChild = (pathStack: number[], currentIndex?: number) => {
     // currentIndex가 있으면 "answer", 없으면 "question" 추가
     const isAddAnswer = currentIndex !== undefined;
-
     const newRoot = isAddAnswer ? saveStatelessPeriNoteData() : deepCopyTree(periNoteData.answerThree);
     const target = getTargetNodeByPath(newRoot, pathStack);
-
-    console.log(target);
 
     if (isAddAnswer) {
       target.children.splice(currentIndex + 1, 0, {
@@ -197,7 +194,7 @@ export default function PeriNote(props: PeriNoteProps) {
         <React.Fragment key={`questionList-${topQuestionIdx}`}>
           <TopQuestionContainer
             pathStack={[topQuestionIdx]}
-            node={topQuestionNode}
+            topQuestionNode={topQuestionNode}
             onAddTopAnswer={handleAddChild}
             onDeleteChild={handleDeleteChild}
             onSetContent={handleSetContent}
@@ -207,7 +204,7 @@ export default function PeriNote(props: PeriNoteProps) {
               key={`topAnswerContainer-${topAnswerIdx}`}
               index={topAnswerIdx}
               pathStack={[topQuestionIdx, topAnswerIdx]}
-              node={topAnswerNode}
+              topAnswerNode={topAnswerNode}
               onAddChild={handleAddChild}
               onDeleteChild={handleDeleteChild}
               onSetContent={handleSetContent}>
@@ -216,7 +213,7 @@ export default function PeriNote(props: PeriNoteProps) {
                   key={`childQANode-${childQAIdx}`}
                   pathStack={[topQuestionIdx, topAnswerIdx, childQAIdx]}
                   index={childQAIdx}
-                  node={childQANode}
+                  childQANode={childQANode}
                   onAddChild={handleAddChild}
                   onDeleteChild={handleDeleteChild}
                   onSetContent={handleSetContent}

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -45,14 +45,14 @@ export default function PeriNote(props: PeriNoteProps) {
 
   const [isPreventedPeriNote, setIsPreventedPeriNote] = useState({ addQuestion: true, isCompleted: true });
 
-  const handleAddChild = (pathStack: number[], currentIndex?: number) => {
+  const handleAddChild = (pathStack: number[], curChildIdx?: number) => {
     // currentIndex가 있으면 "answer", 없으면 "question" 추가
-    const isAddAnswer = currentIndex !== undefined;
+    const isAddAnswer = curChildIdx !== undefined;
     const newRoot = isAddAnswer ? saveStatelessPeriNoteData() : deepCopyTree(periNoteData.answerThree);
     const target = getTargetNodeByPath(newRoot, pathStack);
 
     if (isAddAnswer) {
-      target.children.splice(currentIndex + 1, 0, {
+      target.children.splice(curChildIdx + 1, 0, {
         type: "answer",
         content: "",
         children: [],

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -186,9 +186,7 @@ export default function PeriNote(props: PeriNoteProps) {
 
   useEffect(() => {
     if (textAreaRef.current) {
-      console.log(textAreaRef);
-      // 여기서 조건처리로 큰질문 & 답변에 대한 처리를 해줄 예정입니다.
-      // focus를 어떻게 쓰면 좋을지 생각중입니다.
+      console.log(textAreaRef.current);
     }
   });
 

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -52,6 +52,8 @@ export default function PeriNote(props: PeriNoteProps) {
     const newRoot = isAddAnswer ? saveStatelessPeriNoteData() : deepCopyTree(periNoteData.answerThree);
     const current = getNodeByPath(newRoot, path);
 
+    console.log(current);
+
     if (isAddAnswer) {
       current.children.splice(currentIndex + 1, 0, {
         type: "answer",
@@ -71,6 +73,24 @@ export default function PeriNote(props: PeriNoteProps) {
         ],
       });
     }
+
+    setPeriNoteData({ ...periNoteData, answerThree: newRoot });
+  };
+
+  const handleDeleteChild = (path: number[]) => {
+    const newRoot = deepCopyTree(periNoteData.answerThree);
+    // 삭제할 때는 자신의 부모를 찾아서 children을 제거
+    const parent = getNodeByPath(newRoot, path.slice(0, -1));
+
+    parent.children.splice(path[path.length - 1], 1);
+    setPeriNoteData({ ...periNoteData, answerThree: newRoot });
+  };
+
+  const handleSetContent = (value: string, path: number[]) => {
+    const newRoot = deepCopyTree(periNoteData.answerThree);
+    const current = getNodeByPath(newRoot, path);
+
+    current.content = value;
 
     setPeriNoteData({ ...periNoteData, answerThree: newRoot });
   };
@@ -95,24 +115,6 @@ export default function PeriNote(props: PeriNoteProps) {
     setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
 
     return newRoot;
-  };
-
-  const handleSetContent = (value: string, path: number[]) => {
-    const newRoot = deepCopyTree(periNoteData.answerThree);
-    const current = getNodeByPath(newRoot, path);
-
-    current.content = value;
-
-    setPeriNoteData({ ...periNoteData, answerThree: newRoot });
-  };
-
-  const handleDeleteChild = (path: number[]) => {
-    const newRoot = deepCopyTree(periNoteData.answerThree);
-    // 삭제할 때는 자신의 부모를 찾아서 children을 제거
-    const parent = getNodeByPath(newRoot, path.slice(0, -1));
-
-    parent.children.splice(path[path.length - 1], 1);
-    setPeriNoteData({ ...periNoteData, answerThree: newRoot });
   };
 
   // 규민아 이거 ref로 바꿀 수 있을까?
@@ -216,8 +218,8 @@ export default function PeriNote(props: PeriNoteProps) {
                   index={childQAIdx}
                   node={childQANode}
                   onAddChild={handleAddChild}
-                  onSetContent={handleSetContent}
                   onDeleteChild={handleDeleteChild}
+                  onSetContent={handleSetContent}
                   formController={{ register, setFocus }}
                 />
               ))}

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -43,7 +43,7 @@ export default function PeriNote(props: PeriNoteProps) {
 
   const { getValues, register, setFocus } = useForm<UseForm>();
 
-  const textAreaRef = useRef<HTMLTextAreaElement[]>([]);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const [isPreventedPeriNote, setIsPreventedPeriNote] = useState({ addQuestion: true, isCompleted: true });
 
@@ -185,9 +185,8 @@ export default function PeriNote(props: PeriNoteProps) {
   }, [savingProgress.isPending]);
 
   useEffect(() => {
-    if (textAreaRef.current) {
-      console.log(textAreaRef.current);
-    }
+    // console.log(textAreaRef.current[0][0]);
+    // textAreaRef.current[0][1].focus();
   });
 
   // --------------------------------------------------------------------------
@@ -201,7 +200,7 @@ export default function PeriNote(props: PeriNoteProps) {
       {periNoteData.answerThree.children.map((topQuestionNode, topQuestionIdx) => (
         <React.Fragment key={`questionList-${topQuestionIdx}`}>
           <TopQuestionContainer
-            inheritRef={textAreaRef}
+            ref={textAreaRef}
             pathStack={[topQuestionIdx]}
             topQuestionNode={topQuestionNode}
             onAddTopAnswer={handleAddChild}
@@ -211,7 +210,7 @@ export default function PeriNote(props: PeriNoteProps) {
           {topQuestionNode.children.map((topAnswerNode, topAnswerIdx) => (
             <TopAnswerContainer
               key={`topAnswerContainer-${topAnswerIdx}`}
-              inheritRef={textAreaRef}
+              ref={textAreaRef}
               index={topAnswerIdx}
               pathStack={[topQuestionIdx, topAnswerIdx]}
               topAnswerNode={topAnswerNode}

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -18,7 +18,7 @@ import { useForm } from "react-hook-form";
 import { patchBookNote } from "../../../core/api";
 import { StepUpAndDrawerIdx } from "../../../pages/book-note/[reviewId]";
 import { PeriNoteData, SavingProgress, UseForm } from "../../../types/bookNote";
-import { deepCopyTree, getNodeByPath } from "../../../util/bookNoteTree";
+import { deepCopyTree, getNodeByPath, initialPeriNoteData } from "../../../util/bookNoteTree";
 import useFetchBookNote from "../../../util/hooks/useFetchBookNote";
 import { Loading } from "../../common";
 import { DefaultButton } from "../../common/styled/Button";
@@ -32,21 +32,6 @@ interface PeriNoteProps {
   handleSavingProgress: (obj: SavingProgress) => void;
 }
 
-const initialPeriNoteData: PeriNoteData = {
-  answerThree: {
-    type: "Root",
-    content: "root",
-    children: [
-      {
-        type: "question",
-        content: "",
-        children: [{ type: "answer", content: "", children: [] }],
-      },
-    ],
-  },
-  reviewSt: 3,
-};
-
 export default function PeriNote(props: PeriNoteProps) {
   const { reviewId, handleOpenStepUpModal, handleOpenDrawer, savingProgress, handleSavingProgress } = props;
 
@@ -59,6 +44,7 @@ export default function PeriNote(props: PeriNoteProps) {
   const handleAddChild = (path: number[], currentIndex?: number) => {
     // currentIndex가 있으면 "answer", 없으면 "question" 추가
     const isAddAnswer = currentIndex !== undefined;
+
     const newRoot = isAddAnswer ? saveStatelessPeriNoteData() : deepCopyTree(data.answerThree);
     const current = getNodeByPath(newRoot, path);
 

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -18,7 +18,7 @@ import { useForm } from "react-hook-form";
 import { patchBookNote } from "../../../core/api";
 import { StepUpAndDrawerIdx } from "../../../pages/book-note/[reviewId]";
 import { IPeriNoteData, SavingProgress, UseForm } from "../../../types/bookNote";
-import { deepCopyTree, getNodeByPath, initialPeriNoteData } from "../../../util/bookNoteTree";
+import { deepCopyTree, getTargetNodeByPath, initialPeriNoteData } from "../../../util/bookNoteTree";
 import useFetchBookNote from "../../../util/hooks/useFetchBookNote";
 import { Loading } from "../../common";
 import { DefaultButton } from "../../common/styled/Button";
@@ -50,7 +50,7 @@ export default function PeriNote(props: PeriNoteProps) {
     const isAddAnswer = currentIndex !== undefined;
 
     const newRoot = isAddAnswer ? saveStatelessPeriNoteData() : deepCopyTree(periNoteData.answerThree);
-    const current = getNodeByPath(newRoot, path);
+    const current = getTargetNodeByPath(newRoot, path);
 
     console.log(current);
 
@@ -80,7 +80,7 @@ export default function PeriNote(props: PeriNoteProps) {
   const handleDeleteChild = (path: number[]) => {
     const newRoot = deepCopyTree(periNoteData.answerThree);
     // 삭제할 때는 자신의 부모를 찾아서 children을 제거
-    const parent = getNodeByPath(newRoot, path.slice(0, -1));
+    const parent = getTargetNodeByPath(newRoot, path.slice(0, -1));
 
     parent.children.splice(path[path.length - 1], 1);
     setPeriNoteData({ ...periNoteData, answerThree: newRoot });
@@ -88,7 +88,7 @@ export default function PeriNote(props: PeriNoteProps) {
 
   const handleSetContent = (value: string, path: number[]) => {
     const newRoot = deepCopyTree(periNoteData.answerThree);
-    const current = getNodeByPath(newRoot, path);
+    const current = getTargetNodeByPath(newRoot, path);
 
     current.content = value;
 
@@ -106,7 +106,7 @@ export default function PeriNote(props: PeriNoteProps) {
       const value = obj[key];
       const pathKey = key.split(",").map((k) => parseInt(k));
 
-      const current = getNodeByPath(newRoot, pathKey);
+      const current = getTargetNodeByPath(newRoot, pathKey);
 
       current.content = value;
     });

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -43,7 +43,7 @@ export default function PeriNote(props: PeriNoteProps) {
 
   const { getValues, register, setFocus } = useForm<UseForm>();
 
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const textAreaRef = useRef<HTMLTextAreaElement[]>([]);
 
   const [isPreventedPeriNote, setIsPreventedPeriNote] = useState({ addQuestion: true, isCompleted: true });
 
@@ -74,6 +74,10 @@ export default function PeriNote(props: PeriNoteProps) {
     }
 
     setPeriNoteData({ ...periNoteData, answerThree: newRoot });
+
+    if (pathStack.length === 1) {
+      textAreaRef.current[pathStack[0]][curChildIdx + 2].focus();
+    }
   };
 
   const handleDeleteChild = (pathStack: number[]) => {
@@ -183,11 +187,6 @@ export default function PeriNote(props: PeriNoteProps) {
       }
     }
   }, [savingProgress.isPending]);
-
-  useEffect(() => {
-    // console.log(textAreaRef.current[0][0]);
-    // textAreaRef.current[0][1].focus();
-  });
 
   // --------------------------------------------------------------------------
 

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -17,7 +17,7 @@ import { useForm } from "react-hook-form";
 
 import { patchBookNote } from "../../../core/api";
 import { StepUpAndDrawerIdx } from "../../../pages/book-note/[reviewId]";
-import { PeriNoteData, SavingProgress, UseForm } from "../../../types/bookNote";
+import { IPeriNoteData, SavingProgress, UseForm } from "../../../types/bookNote";
 import { deepCopyTree, getNodeByPath, initialPeriNoteData } from "../../../util/bookNoteTree";
 import useFetchBookNote from "../../../util/hooks/useFetchBookNote";
 import { Loading } from "../../common";
@@ -35,7 +35,7 @@ interface PeriNoteProps {
 export default function PeriNote(props: PeriNoteProps) {
   const { reviewId, handleOpenStepUpModal, handleOpenDrawer, savingProgress, handleSavingProgress } = props;
 
-  const { data, setData, isLoading } = useFetchBookNote<PeriNoteData>(`/review/${reviewId}/peri`, initialPeriNoteData);
+  const { data, setData, isLoading } = useFetchBookNote<IPeriNoteData>(`/review/${reviewId}/peri`, initialPeriNoteData);
 
   const { getValues, register, setFocus } = useForm<UseForm>();
 

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -12,7 +12,7 @@
 */
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { patchBookNote } from "../../../core/api";
@@ -42,6 +42,8 @@ export default function PeriNote(props: PeriNoteProps) {
   } = useFetchBookNote<IPeriNoteData>(`/review/${reviewId}/peri`, initialPeriNoteData);
 
   const { getValues, register, setFocus } = useForm<UseForm>();
+
+  const textAreaRef = useRef<HTMLTextAreaElement[]>([]);
 
   const [isPreventedPeriNote, setIsPreventedPeriNote] = useState({ addQuestion: true, isCompleted: true });
 
@@ -182,6 +184,14 @@ export default function PeriNote(props: PeriNoteProps) {
     }
   }, [savingProgress.isPending]);
 
+  useEffect(() => {
+    if (textAreaRef.current) {
+      console.log(textAreaRef);
+      // 여기서 조건처리로 큰질문 & 답변에 대한 처리를 해줄 예정입니다.
+      // focus를 어떻게 쓰면 좋을지 생각중입니다.
+    }
+  });
+
   // --------------------------------------------------------------------------
 
   if (isLoading) return <Loading />;
@@ -193,6 +203,7 @@ export default function PeriNote(props: PeriNoteProps) {
       {periNoteData.answerThree.children.map((topQuestionNode, topQuestionIdx) => (
         <React.Fragment key={`questionList-${topQuestionIdx}`}>
           <TopQuestionContainer
+            inheritRef={textAreaRef}
             pathStack={[topQuestionIdx]}
             topQuestionNode={topQuestionNode}
             onAddTopAnswer={handleAddChild}
@@ -202,6 +213,7 @@ export default function PeriNote(props: PeriNoteProps) {
           {topQuestionNode.children.map((topAnswerNode, topAnswerIdx) => (
             <TopAnswerContainer
               key={`topAnswerContainer-${topAnswerIdx}`}
+              inheritRef={textAreaRef}
               index={topAnswerIdx}
               pathStack={[topQuestionIdx, topAnswerIdx]}
               topAnswerNode={topAnswerNode}

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -126,7 +126,7 @@ export default function PeriNote(props: PeriNoteProps) {
   };
 
   // 규민아 이거 ref로 바꿀 수 있을까?
-  function toggleMenu(e: React.MouseEvent<HTMLFormElement, MouseEvent>) {
+  const toggleMenu = (e: React.MouseEvent<HTMLFormElement, MouseEvent>) => {
     // as를 없애고 싶다
     const targetElement = e.target as HTMLElement;
 
@@ -152,7 +152,7 @@ export default function PeriNote(props: PeriNoteProps) {
       miniMenu.style.display = "none";
       miniMenu.classList.remove("open");
     }
-  }
+  };
 
   useEffect(() => {
     // 모든 질문 리스트가 지워졌을 경우에는 질문 리스트 추가만 가능하게 하고, 작성완료는 불가하게 함

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -45,23 +45,23 @@ export default function PeriNote(props: PeriNoteProps) {
 
   const [isPreventedPeriNote, setIsPreventedPeriNote] = useState({ addQuestion: true, isCompleted: true });
 
-  const handleAddChild = (path: number[], currentIndex?: number) => {
+  const handleAddChild = (pathStack: number[], currentIndex?: number) => {
     // currentIndex가 있으면 "answer", 없으면 "question" 추가
     const isAddAnswer = currentIndex !== undefined;
 
     const newRoot = isAddAnswer ? saveStatelessPeriNoteData() : deepCopyTree(periNoteData.answerThree);
-    const current = getTargetNodeByPath(newRoot, path);
+    const target = getTargetNodeByPath(newRoot, pathStack);
 
-    console.log(current);
+    console.log(target);
 
     if (isAddAnswer) {
-      current.children.splice(currentIndex + 1, 0, {
+      target.children.splice(currentIndex + 1, 0, {
         type: "answer",
         content: "",
         children: [],
       });
     } else {
-      current.children.push({
+      target.children.push({
         type: "question",
         content: "",
         children: [
@@ -77,20 +77,20 @@ export default function PeriNote(props: PeriNoteProps) {
     setPeriNoteData({ ...periNoteData, answerThree: newRoot });
   };
 
-  const handleDeleteChild = (path: number[]) => {
+  const handleDeleteChild = (pathStack: number[]) => {
     const newRoot = deepCopyTree(periNoteData.answerThree);
     // 삭제할 때는 자신의 부모를 찾아서 children을 제거
-    const parent = getTargetNodeByPath(newRoot, path.slice(0, -1));
+    const parent = getTargetNodeByPath(newRoot, pathStack.slice(0, -1));
 
-    parent.children.splice(path[path.length - 1], 1);
+    parent.children.splice(pathStack[pathStack.length - 1], 1);
     setPeriNoteData({ ...periNoteData, answerThree: newRoot });
   };
 
-  const handleSetContent = (value: string, path: number[]) => {
+  const handleSetContent = (value: string, pathStack: number[]) => {
     const newRoot = deepCopyTree(periNoteData.answerThree);
-    const current = getTargetNodeByPath(newRoot, path);
+    const target = getTargetNodeByPath(newRoot, pathStack);
 
-    current.content = value;
+    target.content = value;
 
     setPeriNoteData({ ...periNoteData, answerThree: newRoot });
   };
@@ -106,13 +106,13 @@ export default function PeriNote(props: PeriNoteProps) {
       const value = obj[key];
       const pathKey = key.split(",").map((k) => parseInt(k));
 
-      const current = getTargetNodeByPath(newRoot, pathKey);
+      const target = getTargetNodeByPath(newRoot, pathKey);
 
-      current.content = value;
+      target.content = value;
     });
 
     // periNoteData state에도 저장
-    setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
+    setPeriNoteData((target) => ({ ...target, answerThree: newRoot }));
 
     return newRoot;
   };
@@ -196,7 +196,7 @@ export default function PeriNote(props: PeriNoteProps) {
       {periNoteData.answerThree.children.map((topQuestionNode, topQuestionIdx) => (
         <React.Fragment key={`questionList-${topQuestionIdx}`}>
           <TopQuestionContainer
-            path={[topQuestionIdx]}
+            pathStack={[topQuestionIdx]}
             node={topQuestionNode}
             onAddTopAnswer={handleAddChild}
             onDeleteChild={handleDeleteChild}
@@ -206,7 +206,7 @@ export default function PeriNote(props: PeriNoteProps) {
             <TopAnswerContainer
               key={`topAnswerContainer-${topAnswerIdx}`}
               index={topAnswerIdx}
-              path={[topQuestionIdx, topAnswerIdx]}
+              pathStack={[topQuestionIdx, topAnswerIdx]}
               node={topAnswerNode}
               onAddChild={handleAddChild}
               onDeleteChild={handleDeleteChild}
@@ -214,7 +214,7 @@ export default function PeriNote(props: PeriNoteProps) {
               {topAnswerNode.children.map((childQANode, childQAIdx) => (
                 <ChildQANode
                   key={`childQANode-${childQAIdx}`}
-                  path={[topQuestionIdx, topAnswerIdx, childQAIdx]}
+                  pathStack={[topQuestionIdx, topAnswerIdx, childQAIdx]}
                   index={childQAIdx}
                   node={childQANode}
                   onAddChild={handleAddChild}

--- a/components/bookNote/periNote/TopAnswerContainer.tsx
+++ b/components/bookNote/periNote/TopAnswerContainer.tsx
@@ -1,7 +1,7 @@
 /*
 마지막 편집자: 22-06-20 joohaem
 변경사항 및 참고:
-  - path: [0, 0], [0, 1], [1, 0], ...
+  - pathStack: [0, 0], [0, 1], [1, 0], ...
     
 고민점:
   - 
@@ -20,29 +20,29 @@ import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 
 interface TopAnswerContainerProps {
   index: number;
-  path: number[];
+  pathStack: number[];
   node: PeriNoteTreeNode;
-  onAddChild: (path: number[], index?: number) => void;
-  onDeleteChild: (path: number[]) => void;
-  onSetContent: (value: string, path: number[]) => void;
+  onAddChild: (pathStack: number[], index?: number) => void;
+  onDeleteChild: (pathStack: number[]) => void;
+  onSetContent: (value: string, pathStack: number[]) => void;
   children: React.ReactNode;
 }
 
 export default function TopAnswerContainer(props: TopAnswerContainerProps) {
-  const { index, path, node, onAddChild, onDeleteChild, onSetContent, children } = props;
+  const { index, pathStack, node, onAddChild, onDeleteChild, onSetContent, children } = props;
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleChangeSetContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (e.target.value !== "\n") {
-      onSetContent(e.target.value, path);
+      onSetContent(e.target.value, pathStack);
     }
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       // add answer (+ index 추가 인자)
-      onAddChild(path.slice(0, -1), index);
+      onAddChild(pathStack.slice(0, -1), index);
     }
   };
 
@@ -69,10 +69,10 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
         />
         <StMore className="icn_more" />
         <StMenuWrapper menuposition="isTopOfQA">
-          <StMenuBtn type="button" onClick={() => onAddChild(path)}>
+          <StMenuBtn type="button" onClick={() => onAddChild(pathStack)}>
             꼬리질문 추가
           </StMenuBtn>
-          <StMenuBtn type="button" onClick={() => onDeleteChild(path)}>
+          <StMenuBtn type="button" onClick={() => onDeleteChild(pathStack)}>
             삭제
           </StMenuBtn>
         </StMenuWrapper>

--- a/components/bookNote/periNote/TopAnswerContainer.tsx
+++ b/components/bookNote/periNote/TopAnswerContainer.tsx
@@ -21,7 +21,7 @@ import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 interface TopAnswerContainerProps {
   index: number;
   pathStack: number[];
-  node: PeriNoteTreeNode;
+  topAnswerNode: PeriNoteTreeNode;
   onAddChild: (pathStack: number[], index?: number) => void;
   onDeleteChild: (pathStack: number[]) => void;
   onSetContent: (value: string, pathStack: number[]) => void;
@@ -29,7 +29,7 @@ interface TopAnswerContainerProps {
 }
 
 export default function TopAnswerContainer(props: TopAnswerContainerProps) {
-  const { index, pathStack, node, onAddChild, onDeleteChild, onSetContent, children } = props;
+  const { index, pathStack, topAnswerNode, onAddChild, onDeleteChild, onSetContent, children } = props;
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -41,6 +41,7 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
       // add answer (+ index 추가 인자)
       onAddChild(pathStack.slice(0, -1), index);
     }
@@ -52,17 +53,17 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
     }
   }, []);
 
-  if (node.type !== "answer") return <></>;
+  if (topAnswerNode.type !== "answer") return <></>;
 
   return (
     <StAnswerWrapper>
-      <StFieldset hasborder={node.children.length > 0}>
+      <StFieldset hasborder={topAnswerNode.children.length > 0}>
         <legend>
           <StAnswerIcon />
         </legend>
         <StInput
           ref={textAreaRef}
-          value={node.content}
+          value={topAnswerNode.content}
           placeholder={"답변을 입력해주세요."}
           onChange={handleChangeSetContent}
           onKeyPress={handleKeyPress}

--- a/components/bookNote/periNote/TopAnswerContainer.tsx
+++ b/components/bookNote/periNote/TopAnswerContainer.tsx
@@ -41,7 +41,6 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
       // add answer (+ index 추가 인자)
       onAddChild(pathStack.slice(0, -1), index);
     }
@@ -50,6 +49,7 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
   useEffect(() => {
     if (textAreaRef.current) {
       textAreaRef.current.focus();
+      console.log(topAnswerNode);
     }
   }, []);
 

--- a/components/bookNote/periNote/TopAnswerContainer.tsx
+++ b/components/bookNote/periNote/TopAnswerContainer.tsx
@@ -9,7 +9,7 @@
 
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import React, { forwardRef } from "react";
+import React, { forwardRef, ReactText, useEffect } from "react";
 import reactTextareaAutosize from "react-textarea-autosize";
 
 import { IcPeriAnswer } from "../../../public/assets/icons";
@@ -53,7 +53,7 @@ function TopAnswerContainer(props: TopAnswerContainerProps, ref: any) {
           <StAnswerIcon />
         </legend>
         <StInput
-          ref={ref}
+          ref={(elem) => (ref.current[pathStack[0]][pathStack[1] + 1] = elem)}
           value={topAnswerNode.content}
           placeholder={"답변을 입력해주세요."}
           onChange={handleChangeSetContent}

--- a/components/bookNote/periNote/TopAnswerContainer.tsx
+++ b/components/bookNote/periNote/TopAnswerContainer.tsx
@@ -9,7 +9,7 @@
 
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import reactTextareaAutosize from "react-textarea-autosize";
 
 import { IcPeriAnswer } from "../../../public/assets/icons";
@@ -20,6 +20,7 @@ import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 
 interface TopAnswerContainerProps {
   index: number;
+  inheritRef: any;
   pathStack: number[];
   topAnswerNode: PeriNoteTreeNode;
   onAddChild: (pathStack: number[], index?: number) => void;
@@ -29,9 +30,7 @@ interface TopAnswerContainerProps {
 }
 
 export default function TopAnswerContainer(props: TopAnswerContainerProps) {
-  const { index, pathStack, topAnswerNode, onAddChild, onDeleteChild, onSetContent, children } = props;
-
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const { index, inheritRef, pathStack, topAnswerNode, onAddChild, onDeleteChild, onSetContent, children } = props;
 
   const handleChangeSetContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (e.target.value !== "\n") {
@@ -46,13 +45,6 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
     }
   };
 
-  useEffect(() => {
-    if (textAreaRef.current) {
-      textAreaRef.current.focus();
-      console.log(topAnswerNode);
-    }
-  }, []);
-
   if (topAnswerNode.type !== "answer") return <></>;
 
   return (
@@ -62,7 +54,7 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
           <StAnswerIcon />
         </legend>
         <StInput
-          ref={textAreaRef}
+          ref={(elem) => inheritRef.current[pathStack[0]].push(elem)}
           value={topAnswerNode.content}
           placeholder={"답변을 입력해주세요."}
           onChange={handleChangeSetContent}

--- a/components/bookNote/periNote/TopAnswerContainer.tsx
+++ b/components/bookNote/periNote/TopAnswerContainer.tsx
@@ -9,7 +9,7 @@
 
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import React from "react";
+import React, { forwardRef } from "react";
 import reactTextareaAutosize from "react-textarea-autosize";
 
 import { IcPeriAnswer } from "../../../public/assets/icons";
@@ -20,7 +20,6 @@ import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 
 interface TopAnswerContainerProps {
   index: number;
-  inheritRef: any;
   pathStack: number[];
   topAnswerNode: PeriNoteTreeNode;
   onAddChild: (pathStack: number[], index?: number) => void;
@@ -29,8 +28,8 @@ interface TopAnswerContainerProps {
   children: React.ReactNode;
 }
 
-export default function TopAnswerContainer(props: TopAnswerContainerProps) {
-  const { index, inheritRef, pathStack, topAnswerNode, onAddChild, onDeleteChild, onSetContent, children } = props;
+function TopAnswerContainer(props: TopAnswerContainerProps, ref: any) {
+  const { index, pathStack, topAnswerNode, onAddChild, onDeleteChild, onSetContent, children } = props;
 
   const handleChangeSetContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (e.target.value !== "\n") {
@@ -54,7 +53,7 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
           <StAnswerIcon />
         </legend>
         <StInput
-          ref={(elem) => (inheritRef.current[pathStack[0]][pathStack[1] + 1] = elem)}
+          ref={ref}
           value={topAnswerNode.content}
           placeholder={"답변을 입력해주세요."}
           onChange={handleChangeSetContent}
@@ -125,3 +124,5 @@ const StInput = styled(reactTextareaAutosize)`
 const StMore = styled(StMoreIcon)`
   margin-right: 3.2rem;
 `;
+
+export default forwardRef(TopAnswerContainer);

--- a/components/bookNote/periNote/TopAnswerContainer.tsx
+++ b/components/bookNote/periNote/TopAnswerContainer.tsx
@@ -54,7 +54,7 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
           <StAnswerIcon />
         </legend>
         <StInput
-          ref={(elem) => inheritRef.current[pathStack[0]].push(elem)}
+          ref={(elem) => (inheritRef.current[pathStack[0]][pathStack[1] + 1] = elem)}
           value={topAnswerNode.content}
           placeholder={"답변을 입력해주세요."}
           onChange={handleChangeSetContent}

--- a/components/bookNote/periNote/TopQuestionContainer.tsx
+++ b/components/bookNote/periNote/TopQuestionContainer.tsx
@@ -19,17 +19,17 @@ import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 
 interface TopQuestionContainerProps {
   pathStack: number[];
-  node: PeriNoteTreeNode;
+  topQuestionNode: PeriNoteTreeNode;
   onAddTopAnswer: (pathStack: number[], currentIndex: number) => void;
   onDeleteChild: (pathStack: number[]) => void;
   onSetContent: (value: string, pathStack: number[]) => void;
 }
 
 export default function TopQuestionContainer(props: TopQuestionContainerProps) {
-  const { pathStack, node, onAddTopAnswer, onDeleteChild, onSetContent } = props;
+  const { pathStack, topQuestionNode, onAddTopAnswer, onDeleteChild, onSetContent } = props;
 
   // 큰 답변 추가시 사용되는 index는 현재 큰질문의 index가 아닌 답변의 개수
-  const currentIndex = node.children.length - 1;
+  const currentIndex = topQuestionNode.children.length - 1;
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -46,12 +46,12 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
   };
 
   useEffect(() => {
-    if (textAreaRef.current) {
+    if (topQuestionNode.content === "" && textAreaRef.current) {
       textAreaRef.current.focus();
     }
   }, []);
 
-  if (node.type !== "question") return <></>;
+  if (topQuestionNode.type !== "question") return <></>;
 
   return (
     <StArticle>
@@ -61,7 +61,7 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
         </legend>
         <StInput
           ref={textAreaRef}
-          value={node.content}
+          value={topQuestionNode.content}
           placeholder="질문을 입력해주세요."
           onChange={handleContent}
           onKeyPress={handleKeyPress}

--- a/components/bookNote/periNote/TopQuestionContainer.tsx
+++ b/components/bookNote/periNote/TopQuestionContainer.tsx
@@ -8,7 +8,7 @@
 */
 
 import styled from "@emotion/styled";
-import React, { forwardRef } from "react";
+import React, { forwardRef, useEffect } from "react";
 import reactTextareaAutosize from "react-textarea-autosize";
 
 import { IcPeriQuestion } from "../../../public/assets/icons";
@@ -52,7 +52,7 @@ function TopQuestionContainer(props: TopQuestionContainerProps, ref: any) {
           <StQuestionIcon />
         </legend>
         <StInput
-          ref={ref}
+          ref={(elem) => (ref.current[pathStack[0]] = [elem])}
           value={topQuestionNode.content}
           placeholder="질문을 입력해주세요."
           onChange={handleContent}

--- a/components/bookNote/periNote/TopQuestionContainer.tsx
+++ b/components/bookNote/periNote/TopQuestionContainer.tsx
@@ -8,7 +8,7 @@
 */
 
 import styled from "@emotion/styled";
-import { useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import reactTextareaAutosize from "react-textarea-autosize";
 
 import { IcPeriQuestion } from "../../../public/assets/icons";
@@ -34,9 +34,7 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (e.target.value !== "\n") {
-      onSetContent(e.target.value, pathStack);
-    }
+    onSetContent(e.target.value, pathStack);
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -46,7 +44,7 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
   };
 
   useEffect(() => {
-    if (topQuestionNode.content === "" && textAreaRef.current) {
+    if (textAreaRef.current) {
       textAreaRef.current.focus();
     }
   }, []);

--- a/components/bookNote/periNote/TopQuestionContainer.tsx
+++ b/components/bookNote/periNote/TopQuestionContainer.tsx
@@ -8,7 +8,7 @@
 */
 
 import styled from "@emotion/styled";
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import reactTextareaAutosize from "react-textarea-autosize";
 
 import { IcPeriQuestion } from "../../../public/assets/icons";
@@ -19,6 +19,7 @@ import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 
 interface TopQuestionContainerProps {
   pathStack: number[];
+  inheritRef: any;
   topQuestionNode: PeriNoteTreeNode;
   onAddTopAnswer: (pathStack: number[], currentIndex: number) => void;
   onDeleteChild: (pathStack: number[]) => void;
@@ -26,15 +27,15 @@ interface TopQuestionContainerProps {
 }
 
 export default function TopQuestionContainer(props: TopQuestionContainerProps) {
-  const { pathStack, topQuestionNode, onAddTopAnswer, onDeleteChild, onSetContent } = props;
+  const { pathStack, inheritRef, topQuestionNode, onAddTopAnswer, onDeleteChild, onSetContent } = props;
 
   // 큰 답변 추가시 사용되는 index는 현재 큰질문의 index가 아닌 답변의 개수
   const currentIndex = topQuestionNode.children.length - 1;
 
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
-
   const handleContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    onSetContent(e.target.value, pathStack);
+    if (e.target.value !== "\n") {
+      onSetContent(e.target.value, pathStack);
+    }
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -42,12 +43,6 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
       onAddTopAnswer(pathStack, currentIndex);
     }
   };
-
-  useEffect(() => {
-    if (textAreaRef.current) {
-      textAreaRef.current.focus();
-    }
-  }, []);
 
   if (topQuestionNode.type !== "question") return <></>;
 
@@ -58,7 +53,7 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
           <StQuestionIcon />
         </legend>
         <StInput
-          ref={textAreaRef}
+          ref={(elem) => (inheritRef.current[pathStack[0]] = [elem])}
           value={topQuestionNode.content}
           placeholder="질문을 입력해주세요."
           onChange={handleContent}

--- a/components/bookNote/periNote/TopQuestionContainer.tsx
+++ b/components/bookNote/periNote/TopQuestionContainer.tsx
@@ -1,7 +1,7 @@
 /*
 마지막 편집자: 22-06-20 joohaem
 변경사항 및 참고:
-  - path: [0], [1], [2], ...
+  - pathStack: [0], [1], [2], ...
     
 고민점:
   - 
@@ -18,15 +18,15 @@ import { StMoreIcon } from "../../common/styled/Icon";
 import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 
 interface TopQuestionContainerProps {
-  path: number[];
+  pathStack: number[];
   node: PeriNoteTreeNode;
-  onAddTopAnswer: (path: number[], currentIndex: number) => void;
-  onDeleteChild: (path: number[]) => void;
-  onSetContent: (value: string, path: number[]) => void;
+  onAddTopAnswer: (pathStack: number[], currentIndex: number) => void;
+  onDeleteChild: (pathStack: number[]) => void;
+  onSetContent: (value: string, pathStack: number[]) => void;
 }
 
 export default function TopQuestionContainer(props: TopQuestionContainerProps) {
-  const { path, node, onAddTopAnswer, onDeleteChild, onSetContent } = props;
+  const { pathStack, node, onAddTopAnswer, onDeleteChild, onSetContent } = props;
 
   // 큰 답변 추가시 사용되는 index는 현재 큰질문의 index가 아닌 답변의 개수
   const currentIndex = node.children.length - 1;
@@ -35,13 +35,13 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
 
   const handleContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (e.target.value !== "\n") {
-      onSetContent(e.target.value, path);
+      onSetContent(e.target.value, pathStack);
     }
   };
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
-      onAddTopAnswer(path, currentIndex);
+      onAddTopAnswer(pathStack, currentIndex);
     }
   };
 
@@ -66,12 +66,12 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
           onChange={handleContent}
           onKeyPress={handleKeyPress}
         />
-        <StAddAnswerButton type="button" onClick={() => onAddTopAnswer(path, currentIndex)}>
+        <StAddAnswerButton type="button" onClick={() => onAddTopAnswer(pathStack, currentIndex)}>
           답변
         </StAddAnswerButton>
         <StMoreIcon className="icn_more" />
         <StMenuWrapper menuposition="isTopOfQA">
-          <StMenuBtn type="button" onClick={() => onDeleteChild(path)}>
+          <StMenuBtn type="button" onClick={() => onDeleteChild(pathStack)}>
             삭제
           </StMenuBtn>
         </StMenuWrapper>

--- a/components/bookNote/periNote/TopQuestionContainer.tsx
+++ b/components/bookNote/periNote/TopQuestionContainer.tsx
@@ -8,7 +8,7 @@
 */
 
 import styled from "@emotion/styled";
-import React from "react";
+import React, { forwardRef } from "react";
 import reactTextareaAutosize from "react-textarea-autosize";
 
 import { IcPeriQuestion } from "../../../public/assets/icons";
@@ -19,15 +19,14 @@ import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 
 interface TopQuestionContainerProps {
   pathStack: number[];
-  inheritRef: any;
   topQuestionNode: PeriNoteTreeNode;
   onAddTopAnswer: (pathStack: number[], currentIndex: number) => void;
   onDeleteChild: (pathStack: number[]) => void;
   onSetContent: (value: string, pathStack: number[]) => void;
 }
 
-export default function TopQuestionContainer(props: TopQuestionContainerProps) {
-  const { pathStack, inheritRef, topQuestionNode, onAddTopAnswer, onDeleteChild, onSetContent } = props;
+function TopQuestionContainer(props: TopQuestionContainerProps, ref: any) {
+  const { pathStack, topQuestionNode, onAddTopAnswer, onDeleteChild, onSetContent } = props;
 
   // 큰 답변 추가시 사용되는 index는 현재 큰질문의 index가 아닌 답변의 개수
   const currentIndex = topQuestionNode.children.length - 1;
@@ -53,7 +52,7 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
           <StQuestionIcon />
         </legend>
         <StInput
-          ref={(elem) => (inheritRef.current[pathStack[0]] = [elem])}
+          ref={ref}
           value={topQuestionNode.content}
           placeholder="질문을 입력해주세요."
           onChange={handleContent}
@@ -121,3 +120,5 @@ const StInput = styled(reactTextareaAutosize)`
     display: none;
   }
 `;
+
+export default forwardRef(TopQuestionContainer);

--- a/components/bookNote/preNote/PreNote.tsx
+++ b/components/bookNote/preNote/PreNote.tsx
@@ -41,23 +41,30 @@ export default function PreNote(props: PreNoteProps) {
     handleSavingProgress,
   } = props;
 
-  const { data, setData, isLoading } = useFetchBookNote<IPreNoteData>(`/review/${reviewId}/pre`, initialPreNoteData);
+  const {
+    data: preNoteData,
+    setData: setPreNoteData,
+    isLoading,
+  } = useFetchBookNote<IPreNoteData>(`/review/${reviewId}/pre`, initialPreNoteData);
 
   const [isFilled, setIsFilled] = useState<boolean>(false);
   const [isFilledOnlyThree, setIsFilledOnlyThree] = useState<boolean>(false);
 
-  const handleChangeReview = <K extends keyof typeof data, V extends typeof data[K]>(key: K, value: V): void => {
-    setData((currentNote) => {
-      const newData = { ...currentNote };
+  const handleChangeReview = <K extends keyof typeof preNoteData, V extends typeof preNoteData[K]>(
+    key: K,
+    value: V,
+  ): void => {
+    setPreNoteData((currentNote) => {
+      const newPreNoteData = { ...currentNote };
 
-      newData[key] = value;
+      newPreNoteData[key] = value;
 
-      return newData;
+      return newPreNoteData;
     });
   };
 
   useEffect(() => {
-    if (data && data.reviewSt > 2) {
+    if (preNoteData && preNoteData.reviewSt > 2) {
       handlePrevent(false);
       setIsFilled(true);
       setIsFilledOnlyThree(true);
@@ -65,26 +72,26 @@ export default function PreNote(props: PreNoteProps) {
       handlePrevent(true);
     }
 
-    if (data && data.answerOne && data.answerTwo && !data.questionList.includes("")) {
+    if (preNoteData && preNoteData.answerOne && preNoteData.answerTwo && !preNoteData.questionList.includes("")) {
       setIsFilled(true);
       setIsFilledOnlyThree(true);
-    } else if (data && !data.questionList.includes("")) {
+    } else if (preNoteData && !preNoteData.questionList.includes("")) {
       setIsFilled(false);
       setIsFilledOnlyThree(true);
     } else {
       setIsFilled(false);
       setIsFilledOnlyThree(false);
     }
-  }, [data]);
+  }, [preNoteData]);
 
   // 네비게이션 바 클릭 시 or 저장하기 버튼 클릭 시 isPending: true
-  // 처음 data 를 fetch 하기 전 initialData 가 곧바로 저장되는 현상을 막아줌
+  // 처음 preNoteData 를 fetch 하기 전 initialData 가 곧바로 저장되는 현상을 막아줌
   useEffect(() => {
-    if (data !== initialPreNoteData && savingProgress.isPending === true) {
+    if (preNoteData !== initialPreNoteData && savingProgress.isPending === true) {
       const _savingProgress = { isPending: false, isError: false };
 
       try {
-        patchBookNote(`/review/${reviewId}/pre`, data);
+        patchBookNote(`/review/${reviewId}/pre`, preNoteData);
       } catch {
         _savingProgress.isError = true;
       } finally {
@@ -108,7 +115,7 @@ export default function PreNote(props: PreNoteProps) {
           onClickOpenDrawer={() => handleOpenDrawer(1)}>
           <StTextarea
             placeholder="답변을 입력해주세요."
-            value={data && data.answerOne}
+            value={preNoteData && preNoteData.answerOne}
             onChange={(e) => handleChangeReview("answerOne", e.target.value)}
           />
         </PreNoteFormContainer>
@@ -119,7 +126,7 @@ export default function PreNote(props: PreNoteProps) {
           onClickOpenDrawer={() => handleOpenDrawer(2)}>
           <StTextarea
             placeholder="답변을 입력해주세요."
-            value={data && data.answerTwo}
+            value={preNoteData && preNoteData.answerTwo}
             onChange={(e) => handleChangeReview("answerTwo", e.target.value)}
           />
         </PreNoteFormContainer>
@@ -130,7 +137,7 @@ export default function PreNote(props: PreNoteProps) {
             onClickStepUpBtn={() => handleOpenStepUpModal(3)}
             onClickOpenDrawer={() => handleOpenDrawer(3)}>
             <PreNoteThirdArticle
-              questionList={data && data.questionList}
+              questionList={preNoteData && preNoteData.questionList}
               onChangeReview={handleChangeReview}
               isPreventedPreNote={isPreventedPreNote}
               isFilledOnlyThree={isFilledOnlyThree}
@@ -142,7 +149,7 @@ export default function PreNote(props: PreNoteProps) {
       </StFormWrapper>
 
       <PreNotePostSection
-        bookNoteData={data}
+        preNoteData={preNoteData}
         isFilled={isFilled}
         handlePrevent={handlePrevent}
         handleNavIndex={handleNavIndex}

--- a/components/bookNote/preNote/PreNote.tsx
+++ b/components/bookNote/preNote/PreNote.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 
 import { patchBookNote } from "../../../core/api";
 import { StepUpAndDrawerIdx } from "../../../pages/book-note/[reviewId]";
-import { BookNotePathKey, PreNoteData, SavingProgress } from "../../../types/bookNote";
+import { BookNotePathKey, IPreNoteData, SavingProgress } from "../../../types/bookNote";
 import useFetchBookNote from "../../../util/hooks/useFetchBookNote";
 import { Loading } from "../../common";
 import { LinkToSignUpSection, PreNoteFormContainer, PreNotePostSection, PreNoteThirdArticle } from ".";
@@ -20,7 +20,7 @@ interface PreNoteProps {
   handleSavingProgress: (obj: SavingProgress) => void;
 }
 
-const initialPreNoteData: PreNoteData = {
+const initialPreNoteData: IPreNoteData = {
   answerOne: "",
   answerTwo: "",
   questionList: [""],
@@ -41,7 +41,7 @@ export default function PreNote(props: PreNoteProps) {
     handleSavingProgress,
   } = props;
 
-  const { data, setData, isLoading } = useFetchBookNote<PreNoteData>(`/review/${reviewId}/pre`, initialPreNoteData);
+  const { data, setData, isLoading } = useFetchBookNote<IPreNoteData>(`/review/${reviewId}/pre`, initialPreNoteData);
 
   const [isFilled, setIsFilled] = useState<boolean>(false);
   const [isFilledOnlyThree, setIsFilledOnlyThree] = useState<boolean>(false);

--- a/components/bookNote/preNote/PreNotePostSection.tsx
+++ b/components/bookNote/preNote/PreNotePostSection.tsx
@@ -21,7 +21,7 @@ import { useRecoilValue } from "recoil";
 import { patchBookNote } from "../../../core/api";
 import { navigatingBookInfoState } from "../../../core/atom";
 import { ImgPreBook } from "../../../public/assets/images";
-import { BookNotePathKey, PeriNoteTreeNode, PreNoteData } from "../../../types/bookNote";
+import { BookNotePathKey, IPreNoteData, PeriNoteTreeNode } from "../../../types/bookNote";
 import { DefaultButton } from "../../common/styled/Button";
 import { ImageWrapper } from "../../common/styled/Img";
 import {
@@ -35,7 +35,7 @@ import {
 } from "../../common/styled/PopUp";
 
 interface PreNotePostSectionProps {
-  bookNoteData: PreNoteData;
+  bookNoteData: IPreNoteData;
   isFilled: boolean;
   handlePrevent: (shouldPrevent: boolean) => void;
   handleNavIndex: (idx: BookNotePathKey) => void;

--- a/components/bookNote/preNote/PreNotePostSection.tsx
+++ b/components/bookNote/preNote/PreNotePostSection.tsx
@@ -35,14 +35,14 @@ import {
 } from "../../common/styled/PopUp";
 
 interface PreNotePostSectionProps {
-  bookNoteData: IPreNoteData;
+  preNoteData: IPreNoteData;
   isFilled: boolean;
   handlePrevent: (shouldPrevent: boolean) => void;
   handleNavIndex: (idx: BookNotePathKey) => void;
 }
 
 export default function PreNotePostSection(props: PreNotePostSectionProps) {
-  const { isFilled, bookNoteData, handlePrevent, handleNavIndex } = props;
+  const { isFilled, preNoteData, handlePrevent, handleNavIndex } = props;
 
   const navigatingBookInfo = useRecoilValue(navigatingBookInfoState);
   const { reviewId } = navigatingBookInfo;
@@ -51,13 +51,13 @@ export default function PreNotePostSection(props: PreNotePostSectionProps) {
 
   const handleSubmit = async () => {
     try {
-      if (bookNoteData.reviewSt === 2) {
+      if (preNoteData.reviewSt === 2) {
         // 독서 전 상태라면, 독서 중 상태로 변경하고 질문리스트를 독서 중으로 넘겨준다
-        await patchBookNote(`/review/${reviewId}/pre`, { ...bookNoteData, reviewSt: 3 });
+        await patchBookNote(`/review/${reviewId}/pre`, { ...preNoteData, reviewSt: 3 });
 
         const questionFromPre: PeriNoteTreeNode[] = [];
 
-        bookNoteData.questionList.map((content) => {
+        preNoteData.questionList.map((content) => {
           questionFromPre.push({
             type: "question",
             content,
@@ -76,7 +76,7 @@ export default function PreNotePostSection(props: PreNotePostSectionProps) {
         });
       } else {
         // 독서 전 상태가 아니라면, 독서 전 데이터만 수정한다
-        await patchBookNote(`/review/${reviewId}/pre`, bookNoteData);
+        await patchBookNote(`/review/${reviewId}/pre`, preNoteData);
       }
 
       // flushsync 필요하면 사용해야 함!
@@ -92,7 +92,7 @@ export default function PreNotePostSection(props: PreNotePostSectionProps) {
     <>
       <StNextBtn
         type="button"
-        disabled={!isFilled || bookNoteData.questionList.length === 0}
+        disabled={!isFilled || preNoteData.questionList.length === 0}
         onClick={() => setIsOpenedModal(true)}>
         다음 계단
       </StNextBtn>

--- a/components/bookNote/preNote/PreNoteThirdArticle.tsx
+++ b/components/bookNote/preNote/PreNoteThirdArticle.tsx
@@ -2,10 +2,10 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import React, { useState } from "react";
 
-import { PreNoteData } from "../../../types/bookNote";
+import { IPreNoteData } from "../../../types/bookNote";
 import InputQuestion from "./InputQuestion";
 
-const preNoteData: PreNoteData = {
+const preNoteData: IPreNoteData = {
   answerOne: "",
   answerTwo: "",
   questionList: [""],

--- a/components/main/RecentBooks.tsx
+++ b/components/main/RecentBooks.tsx
@@ -27,7 +27,7 @@ export default function RecentBooks() {
         <StHeader>
           <StHeading3>최근 작성한 북노트</StHeading3>
           {isNotEmpty && (
-            <Link href="/main/bookcase">
+            <Link href="/main/bookcase" passHref>
               <StLink>전체보기</StLink>
             </Link>
           )}

--- a/components/main/RecentBooks.tsx
+++ b/components/main/RecentBooks.tsx
@@ -27,7 +27,7 @@ export default function RecentBooks() {
         <StHeader>
           <StHeading3>최근 작성한 북노트</StHeading3>
           {isNotEmpty && (
-            <Link href="/main/bookcase" passHref>
+            <Link href="/bookcase" passHref>
               <StLink>전체보기</StLink>
             </Link>
           )}

--- a/core/api.ts
+++ b/core/api.ts
@@ -11,7 +11,7 @@ import useSWR from "swr";
 
 import { KAKAOParams, Response, ResponseDto } from "../types";
 import { BookcaseInfo } from "../types/bookcase";
-import { PeriNoteData, PreNoteData } from "../types/bookNote";
+import { IPeriNoteData, IPreNoteData } from "../types/bookNote";
 import { IsValid, UseFormDataType } from "../types/signup";
 import { baseInstance, kakaoInstance } from "./axios";
 import LocalStorage from "./localStorage";
@@ -28,7 +28,7 @@ export const patchUserWithdraw = (key: string) => {
   return baseInstance.patch(key);
 };
 
-export const patchBookNote = async (key: string, body: PreNoteData | PeriNoteData) => {
+export const patchBookNote = async (key: string, body: IPreNoteData | IPeriNoteData) => {
   const { data } = await baseInstance.patch(key, body);
 
   return data;

--- a/core/api.ts
+++ b/core/api.ts
@@ -38,7 +38,7 @@ export const deleteData = (key: string) => {
   return baseInstance.delete(key);
 };
 
-export function useGetBookInfo(key: string) {
+export const useGetBookInfo = (key: string) => {
   const urlKey = key === "/main" ? "/book" : key;
   const { data, error } = useSWR<Response<{ books: BookcaseInfo[] }>>(urlKey, baseInstance.get);
 
@@ -47,7 +47,7 @@ export function useGetBookInfo(key: string) {
     isLoading: !error && !data,
     isError: error,
   };
-}
+};
 
 export const signup = async (userData: UseFormDataType, password: string) => {
   try {

--- a/pages/book-note/[reviewId]/index.tsx
+++ b/pages/book-note/[reviewId]/index.tsx
@@ -13,7 +13,7 @@
 
 import { css, keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { flushSync } from "react-dom";
 import { useRecoilValue } from "recoil";
 

--- a/types/bookNote.ts
+++ b/types/bookNote.ts
@@ -18,12 +18,12 @@ export interface PeriNoteTreeNode {
 //   reviewSt: number;
 // }
 
-export interface PeriNoteData {
+export interface IPeriNoteData {
   answerThree: PeriNoteTreeNode;
   reviewSt: 2 | 3 | 4;
 }
 
-export interface PreNoteData {
+export interface IPreNoteData {
   answerOne: string;
   answerTwo: string;
   questionList: string[];

--- a/util/bookNoteTree.ts
+++ b/util/bookNoteTree.ts
@@ -7,7 +7,22 @@
 - deepCopyTree --> immer.js 라이브러리로 치환 예정입니다
 */
 
-import { PeriNoteTreeNode } from "../types/bookNote";
+import { PeriNoteData, PeriNoteTreeNode } from "../types/bookNote";
+
+export const initialPeriNoteData: PeriNoteData = {
+  answerThree: {
+    type: "Root",
+    content: "root",
+    children: [
+      {
+        type: "question",
+        content: "",
+        children: [{ type: "answer", content: "", children: [] }],
+      },
+    ],
+  },
+  reviewSt: 3,
+};
 
 export const deepCopyTree = (root: PeriNoteTreeNode): PeriNoteTreeNode => {
   const newRoot = {

--- a/util/bookNoteTree.ts
+++ b/util/bookNoteTree.ts
@@ -35,7 +35,8 @@ export const deepCopyTree = (root: PeriNoteTreeNode): PeriNoteTreeNode => {
   return newRoot;
 };
 
-export const getNodeByPath = (rootNode: PeriNoteTreeNode, pathIndices: number[]): PeriNoteTreeNode => {
+// rootNode와 map으로부터 생성되는 idx를 배열에 넣어, 노드 경로를 탐색하고 타깃 노드(꼬리질문 삭제, 답변 추가 등 선택)가 무엇인지 찾기
+export const getTargetNodeByPath = (rootNode: PeriNoteTreeNode, pathIndices: number[]): PeriNoteTreeNode => {
   if (rootNode === undefined) {
     throw new Error("something wrong getting rootNode by pathIndices");
   }
@@ -44,5 +45,5 @@ export const getNodeByPath = (rootNode: PeriNoteTreeNode, pathIndices: number[])
     return rootNode;
   }
 
-  return getNodeByPath(rootNode.children[pathIndices[0]], pathIndices.slice(1));
+  return getTargetNodeByPath(rootNode.children[pathIndices[0]], pathIndices.slice(1));
 };

--- a/util/bookNoteTree.ts
+++ b/util/bookNoteTree.ts
@@ -35,14 +35,14 @@ export const deepCopyTree = (root: PeriNoteTreeNode): PeriNoteTreeNode => {
   return newRoot;
 };
 
-export const getNodeByPath = (node: PeriNoteTreeNode, path: number[]): PeriNoteTreeNode => {
-  if (node === undefined) {
-    throw new Error("something wrong getting node by path");
+export const getNodeByPath = (rootNode: PeriNoteTreeNode, pathIndices: number[]): PeriNoteTreeNode => {
+  if (rootNode === undefined) {
+    throw new Error("something wrong getting rootNode by pathIndices");
   }
 
-  if (path.length === 0) {
-    return node;
+  if (pathIndices.length === 0) {
+    return rootNode;
   }
 
-  return getNodeByPath(node.children[path[0]], path.slice(1));
+  return getNodeByPath(rootNode.children[pathIndices[0]], pathIndices.slice(1));
 };

--- a/util/bookNoteTree.ts
+++ b/util/bookNoteTree.ts
@@ -7,9 +7,9 @@
 - deepCopyTree --> immer.js 라이브러리로 치환 예정입니다
 */
 
-import { PeriNoteData, PeriNoteTreeNode } from "../types/bookNote";
+import { IPeriNoteData, PeriNoteTreeNode } from "../types/bookNote";
 
-export const initialPeriNoteData: PeriNoteData = {
+export const initialPeriNoteData: IPeriNoteData = {
   answerThree: {
     type: "Root",
     content: "root",
@@ -24,6 +24,7 @@ export const initialPeriNoteData: PeriNoteData = {
   reviewSt: 3,
 };
 
+// 재귀 함수
 export const deepCopyTree = (root: PeriNoteTreeNode): PeriNoteTreeNode => {
   const newRoot = {
     type: root.type,

--- a/util/bookNoteTree.ts
+++ b/util/bookNoteTree.ts
@@ -36,14 +36,14 @@ export const deepCopyTree = (root: PeriNoteTreeNode): PeriNoteTreeNode => {
 };
 
 // rootNode와 map으로부터 생성되는 idx를 배열에 넣어, 노드 경로를 탐색하고 타깃 노드(꼬리질문 삭제, 답변 추가 등 선택)가 무엇인지 찾기
-export const getTargetNodeByPath = (rootNode: PeriNoteTreeNode, pathIndices: number[]): PeriNoteTreeNode => {
+export const getTargetNodeByPath = (rootNode: PeriNoteTreeNode, pathStack: number[]): PeriNoteTreeNode => {
   if (rootNode === undefined) {
-    throw new Error("something wrong getting rootNode by pathIndices");
+    throw new Error("something wrong getting rootNode by pathStack");
   }
 
-  if (pathIndices.length === 0) {
+  if (pathStack.length === 0) {
     return rootNode;
   }
 
-  return getTargetNodeByPath(rootNode.children[pathIndices[0]], pathIndices.slice(1));
+  return getTargetNodeByPath(rootNode.children[pathStack[0]], pathStack.slice(1));
 };


### PR DESCRIPTION
## 📌 나 이런 거 했어요
**`큰 질문 & 답변에 대한 오류를 수정하고자 합니다.`**

1. useEffect를 통해 큰 질문, 답변 두 개의 컴포넌트에서 각각 map을 통해 렌더링되다 보니 focus를 제어하기가 어렵습니다. 
(독서 전 -> 중으로 넘어올 때 첫 번째 큰 질문의 답변에 focusing, 큰 질문을 추가했을때에는 새롭게 추가된 질문에 focusing, 큰 답변 추가시 추가되는 곳에 focusing 등)

2. 부모 컴포넌트로 useRef를 올리고 배열로 초기화하여 current를 설정하여 focusing 할 수 있는지 고민하고 있습니다.

<br />

## 📌 나 이런 거 알게 되었어요

- useRef의 구조에 대해서 조금 더 알게 되었습니다만, useRef의 목적이 크게 두 가지로 특정 DOM을 선택하는 경우, 다시 렌더링 되어도 동일한 참조값을 유지하기 위한 경우 정도로 나와 있습니다. 제가 후자의 경우로 이용하는것 같은데 그 이유는 focus기능이 상실된 것 같아서 입니다! 봐주시면 감사하겠습니다.
- ref값을 props로 내리는 경우 그냥 주는 것이 아니라 forwardRef 를 통해 주는 방법도 있었는데, 이는 더 공부해보겠습니다.

<br />

## 📌 나 이런 거 궁금해요

- QA Node는 마지막으로 렌더링되고, useForm 의 setFocus를 이용하다보니 큰 질문&답변에서는 이렇게 해도 문제가 없을 것으로 생각이 됩니다. 이 방식이 무리하다면, 다른 방법을 모색해보겠습니다.
