### PR TITLE
[Feature] feat: 질문 답변 추가 로직 Align 및 리팩토링

### DIFF
--- a/components/bookNote/periNote/ChildQANode.tsx
+++ b/components/bookNote/periNote/ChildQANode.tsx
@@ -23,14 +23,28 @@ interface ChildQANodeProps {
   pathStack: number[];
   index: number;
   node: PeriNoteTreeNode;
-  onAddChild: (pathStack: number[], index?: number) => void;
+  onAddChildQuestion: (pathStack: number[]) => void;
+  onAddSiblingQuestion: (pathStack: number[], currentIndex: number) => void;
+  onAddChildAnswer: (pathStack: number[]) => void;
+  onAddSiblingAnswer: (pathStack: number[], currentIndex: number) => void;
   // urgentQuery 제거시, setContent 불필요
   onSetContent: (value: string, pathStack: number[]) => void;
   onDeleteChild: (pathStack: number[]) => void;
   formController: FormController;
 }
 export default function ChildQANode(props: ChildQANodeProps) {
-  const { pathStack, index, node, onAddChild, onSetContent, onDeleteChild, formController } = props;
+  const {
+    pathStack,
+    index,
+    node,
+    onAddChildQuestion,
+    onAddSiblingQuestion,
+    onAddChildAnswer,
+    onAddSiblingAnswer,
+    onSetContent,
+    onDeleteChild,
+    formController,
+  } = props;
 
   // TODO :: state 제거
   const { urgentQuery, setUrgentQuery } = useUpdatePeriNote(node.content, pathStack, onSetContent);
@@ -45,8 +59,8 @@ export default function ChildQANode(props: ChildQANodeProps) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       // 꼬리질문과 답변은 자신의 아래에 추가하는 것이 아닌 자신의 부모의 children에 추가해야함
-      if (isQuestion) onAddChild(pathStack.slice(0, -1));
-      else onAddChild(pathStack.slice(0, -1), index);
+      if (isQuestion) onAddSiblingQuestion(pathStack.slice(0, -1), index);
+      else onAddSiblingAnswer(pathStack.slice(0, -1), index);
     }
   };
 
@@ -87,14 +101,14 @@ export default function ChildQANode(props: ChildQANodeProps) {
             onKeyPress={addChildByEnter}
           />
           {isQuestion && (
-            <StAddAnswerButton type="button" onClick={() => onAddChild(pathStack, index + 1)}>
+            <StAddAnswerButton type="button" onClick={() => onAddChildAnswer(pathStack)}>
               답변
             </StAddAnswerButton>
           )}
           <StMore className="icn_more" />
           <StMenuWrapper>
             {!isQuestion && canAddChild && (
-              <StMenuBtn type="button" onClick={() => onAddChild(pathStack)}>
+              <StMenuBtn type="button" onClick={() => onAddChildQuestion(pathStack)}>
                 꼬리질문 추가
               </StMenuBtn>
             )}
@@ -112,7 +126,10 @@ export default function ChildQANode(props: ChildQANodeProps) {
               pathStack={[...pathStack, i]}
               index={i}
               node={node}
-              onAddChild={onAddChild}
+              onAddSiblingQuestion={onAddSiblingQuestion}
+              onAddChildAnswer={onAddChildAnswer}
+              onAddSiblingAnswer={onAddSiblingAnswer}
+              onAddChildQuestion={onAddChildQuestion}
               onDeleteChild={onDeleteChild}
               onSetContent={onSetContent}
               formController={formController}

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -107,6 +107,7 @@ export default function PeriNote(props: PeriNoteProps) {
           <TopQuestionContainer
             pathStack={[topQuestionIdx]}
             node={topQuestionNode}
+            onAddSiblingQuestion={handleAddSiblingQuestion}
             onAddTopAnswer={handleAddSiblingAnswer}
             onDeleteChild={handleDeleteChild}
             onSetContent={handleSetContent}

--- a/components/bookNote/periNote/PeriNote.tsx
+++ b/components/bookNote/periNote/PeriNote.tsx
@@ -16,11 +16,9 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { v4 as uuidv4 } from "uuid";
 
 import { StepUpAndDrawerIdx } from "../../../pages/book-note/[reviewId]";
 import { UseForm } from "../../../types/bookNote";
-import { deepCopyTree, getTargetNodeByPath } from "../../../util/bookNoteTree";
 import usePeriNote from "../../../util/hooks/bookNote/usePeriNote";
 import { DefaultButton } from "../../common/styled/Button";
 import { ChildQANode, HeaderLabel, PeriNotePostSection, TopAnswerContainer, TopQuestionContainer } from ".";
@@ -34,70 +32,21 @@ interface PeriNoteProps {
 export default function PeriNote(props: PeriNoteProps) {
   const { reviewId, handleOpenStepUpModal, handleOpenDrawer } = props;
 
-  const { periNoteData, setPeriNoteData } = usePeriNote(reviewId);
-
   const { register, setFocus } = useForm<UseForm>();
-
   const [isPreventedPeriNote, setIsPreventedPeriNote] = useState({ addQuestion: true, isCompleted: true });
+  const {
+    periNoteData,
+    handleAddChildAnswer,
+    handleAddSiblingAnswer,
+    handleAddChildQuestion,
+    handleAddSiblingQuestion,
+    handleSetContent,
+    handleDeleteChild,
+  } = usePeriNote(reviewId);
 
-  const handleAddChild = (pathStack: number[], currentIndex?: number) => {
-    // currentIndex가 있으면 "answer", 없으면 "question" 추가
-    const isAddAnswer = currentIndex !== undefined;
-    const newRoot = deepCopyTree(periNoteData.answerThree);
-    const targetNode = getTargetNodeByPath(newRoot, pathStack);
-
-    if (isAddAnswer) {
-      targetNode.children.splice(currentIndex + 1, 0, {
-        id: uuidv4(),
-        type: "answer",
-        content: "",
-        children: [],
-      });
-    } else {
-      targetNode.children.push({
-        id: uuidv4(),
-        type: "question",
-        content: "",
-        children: [
-          {
-            id: uuidv4(),
-            type: "answer",
-            content: "",
-            children: [],
-          },
-        ],
-      });
-    }
-
-    setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
-  };
-
-  const handleSetContent = (value: string, pathStack: number[]) => {
-    const newRoot = deepCopyTree(periNoteData.answerThree);
-    const current = getTargetNodeByPath(newRoot, pathStack);
-
-    current.content = value;
-
-    setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
-  };
-
-  const handleDeleteChild = (pathStack: number[]) => {
-    const newRoot = deepCopyTree(periNoteData.answerThree);
-    // 삭제할 때는 자신의 부모를 찾아서 children을 제거
-    const parent = getTargetNodeByPath(newRoot, pathStack.slice(0, -1));
-
-    // parent.children.splice(pathStack[pathStack.length - 1], 1);
-    parent.children[pathStack[pathStack.length - 1]] = {
-      ...parent.children[pathStack[pathStack.length - 1]],
-      type: "deleted",
-    };
-
-    setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
-  };
-
-  // 규민아 이거 ref로 바꿀 수 있을까?
+  // TODO :: Ref 이용
   function toggleMenu(e: React.MouseEvent<HTMLFormElement, MouseEvent>) {
-    // as를 없애고 싶다
+    // TODO :: as 삭제
     const targetElement = e.target as HTMLElement;
 
     if (!targetElement.closest(".icn_more")) {
@@ -158,7 +107,7 @@ export default function PeriNote(props: PeriNoteProps) {
           <TopQuestionContainer
             pathStack={[topQuestionIdx]}
             node={topQuestionNode}
-            onAddTopAnswer={handleAddChild}
+            onAddTopAnswer={handleAddSiblingAnswer}
             onDeleteChild={handleDeleteChild}
             onSetContent={handleSetContent}
           />
@@ -168,7 +117,8 @@ export default function PeriNote(props: PeriNoteProps) {
               index={topAnswerIdx}
               pathStack={[topQuestionIdx, topAnswerIdx]}
               node={topAnswerNode}
-              onAddChild={handleAddChild}
+              onAddSiblingAnswer={handleAddSiblingAnswer}
+              onAddChildQuestion={handleAddChildQuestion}
               onDeleteChild={handleDeleteChild}
               onSetContent={handleSetContent}>
               {topAnswerNode.children.map((childQANode, childQAIdx) => (
@@ -177,7 +127,10 @@ export default function PeriNote(props: PeriNoteProps) {
                   pathStack={[topQuestionIdx, topAnswerIdx, childQAIdx]}
                   index={childQAIdx}
                   node={childQANode}
-                  onAddChild={handleAddChild}
+                  onAddChildQuestion={handleAddChildQuestion}
+                  onAddSiblingQuestion={handleAddSiblingQuestion}
+                  onAddChildAnswer={handleAddChildAnswer}
+                  onAddSiblingAnswer={handleAddSiblingAnswer}
                   onSetContent={handleSetContent}
                   onDeleteChild={handleDeleteChild}
                   formController={{ register, setFocus }}
@@ -188,7 +141,10 @@ export default function PeriNote(props: PeriNoteProps) {
         </React.Fragment>
       ))}
 
-      <StAddChildButton type="button" disabled={isPreventedPeriNote.addQuestion} onClick={() => handleAddChild([])}>
+      <StAddChildButton
+        type="button"
+        disabled={isPreventedPeriNote.addQuestion}
+        onClick={() => handleAddChildQuestion([])}>
         질문 리스트 추가
       </StAddChildButton>
 

--- a/components/bookNote/periNote/TopAnswerContainer.tsx
+++ b/components/bookNote/periNote/TopAnswerContainer.tsx
@@ -13,14 +13,16 @@ interface TopAnswerContainerProps {
   index: number;
   pathStack: number[];
   node: PeriNoteTreeNode;
-  onAddChild: (pathStack: number[], index?: number) => void;
+  onAddSiblingAnswer: (pathStack: number[], currentIndex: number) => void;
+  onAddChildQuestion: (pathStack: number[]) => void;
   onDeleteChild: (pathStack: number[]) => void;
   onSetContent: (value: string, pathStack: number[]) => void;
   children: React.ReactNode;
 }
 
 export default function TopAnswerContainer(props: TopAnswerContainerProps) {
-  const { index, pathStack, node, onAddChild, onDeleteChild, onSetContent, children } = props;
+  const { index, pathStack, node, onAddSiblingAnswer, onAddChildQuestion, onDeleteChild, onSetContent, children } =
+    props;
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -33,7 +35,7 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       // add answer (+ index 추가 인자)
-      onAddChild(pathStack.slice(0, -1), index);
+      onAddSiblingAnswer(pathStack.slice(0, -1), index);
     }
   };
 
@@ -60,7 +62,7 @@ export default function TopAnswerContainer(props: TopAnswerContainerProps) {
         />
         <StMore className="icn_more" />
         <StMenuWrapper menuposition="isTopOfQA">
-          <StMenuBtn type="button" onClick={() => onAddChild(pathStack)}>
+          <StMenuBtn type="button" onClick={() => onAddChildQuestion(pathStack)}>
             꼬리질문 추가
           </StMenuBtn>
           <StMenuBtn type="button" onClick={() => onDeleteChild(pathStack)}>

--- a/components/bookNote/periNote/TopQuestionContainer.tsx
+++ b/components/bookNote/periNote/TopQuestionContainer.tsx
@@ -11,13 +11,14 @@ import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 interface TopQuestionContainerProps {
   pathStack: number[];
   node: PeriNoteTreeNode;
+  onAddSiblingQuestion: (pathStack: number[], currentIndex: number) => void;
   onAddTopAnswer: (pathStack: number[], currentChildrenIndex: number) => void;
   onDeleteChild: (pathStack: number[]) => void;
   onSetContent: (value: string, pathStack: number[]) => void;
 }
 
 export default function TopQuestionContainer(props: TopQuestionContainerProps) {
-  const { pathStack, node, onAddTopAnswer, onDeleteChild, onSetContent } = props;
+  const { pathStack, node, onAddSiblingQuestion, onAddTopAnswer, onDeleteChild, onSetContent } = props;
 
   // 큰 답변 추가시 사용되는 index는 현재 큰질문의 index가 아닌 답변의 개수
   const currentChildrenIndex = node.children.length - 1;
@@ -32,7 +33,7 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
-      onAddTopAnswer(pathStack, currentChildrenIndex);
+      onAddSiblingQuestion(pathStack.slice(0, -1), currentChildrenIndex);
     }
   };
 

--- a/components/bookNote/periNote/TopQuestionContainer.tsx
+++ b/components/bookNote/periNote/TopQuestionContainer.tsx
@@ -11,7 +11,7 @@ import { StMenuWrapper } from "../../common/styled/MenuWrapper";
 interface TopQuestionContainerProps {
   pathStack: number[];
   node: PeriNoteTreeNode;
-  onAddTopAnswer: (pathStack: number[], currentIndex: number) => void;
+  onAddTopAnswer: (pathStack: number[], currentChildrenIndex: number) => void;
   onDeleteChild: (pathStack: number[]) => void;
   onSetContent: (value: string, pathStack: number[]) => void;
 }
@@ -20,7 +20,7 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
   const { pathStack, node, onAddTopAnswer, onDeleteChild, onSetContent } = props;
 
   // 큰 답변 추가시 사용되는 index는 현재 큰질문의 index가 아닌 답변의 개수
-  const currentIndex = node.children.length - 1;
+  const currentChildrenIndex = node.children.length - 1;
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -32,7 +32,7 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
-      onAddTopAnswer(pathStack, currentIndex);
+      onAddTopAnswer(pathStack, currentChildrenIndex);
     }
   };
 
@@ -57,7 +57,7 @@ export default function TopQuestionContainer(props: TopQuestionContainerProps) {
           onChange={handleContent}
           onKeyPress={handleKeyPress}
         />
-        <StAddAnswerButton type="button" onClick={() => onAddTopAnswer(pathStack, currentIndex)}>
+        <StAddAnswerButton type="button" onClick={() => onAddTopAnswer(pathStack, currentChildrenIndex)}>
           답변
         </StAddAnswerButton>
         <StMoreIcon className="icn_more" />

--- a/util/hooks/bookNote/usePeriNote.ts
+++ b/util/hooks/bookNote/usePeriNote.ts
@@ -10,6 +10,7 @@
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useRecoilRefresher_UNSTABLE, useRecoilState, useRecoilValueLoadable } from "recoil";
+import { v4 as uuidv4 } from "uuid";
 
 import { patchPeriNoteData } from "../../../core/api/review";
 import { editInitializePeriNoteSelector, periNoteState } from "../../../core/atom/bookNote";
@@ -66,11 +67,105 @@ export default function usePeriNote(reviewId: string) {
     return response;
   }
 
+  const handleAddChildAnswer = (pathStack: number[]) => {
+    const newRoot = deepCopyTree(periNoteData.answerThree);
+    const targetNode = getTargetNodeByPath(newRoot, pathStack);
+
+    targetNode.children.push({
+      id: uuidv4(),
+      type: "answer",
+      content: "",
+      children: [],
+    });
+    setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
+  };
+
+  const handleAddSiblingAnswer = (pathStack: number[], currentIndex: number) => {
+    const newRoot = deepCopyTree(periNoteData.answerThree);
+    const targetNode = getTargetNodeByPath(newRoot, pathStack);
+
+    targetNode.children.splice(currentIndex + 1, 0, {
+      id: uuidv4(),
+      type: "answer",
+      content: "",
+      children: [],
+    });
+    setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
+  };
+
+  const handleAddChildQuestion = (pathStack: number[]) => {
+    const newRoot = deepCopyTree(periNoteData.answerThree);
+    const targetNode = getTargetNodeByPath(newRoot, pathStack);
+
+    targetNode.children.push({
+      id: uuidv4(),
+      type: "question",
+      content: "",
+      children: [
+        {
+          id: uuidv4(),
+          type: "answer",
+          content: "",
+          children: [],
+        },
+      ],
+    });
+    setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
+  };
+
+  const handleAddSiblingQuestion = (pathStack: number[], currentIndex: number) => {
+    const newRoot = deepCopyTree(periNoteData.answerThree);
+    const targetNode = getTargetNodeByPath(newRoot, pathStack);
+
+    targetNode.children.splice(currentIndex + 1, 0, {
+      id: uuidv4(),
+      type: "question",
+      content: "",
+      children: [
+        {
+          id: uuidv4(),
+          type: "answer",
+          content: "",
+          children: [],
+        },
+      ],
+    });
+    setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
+  };
+
+  const handleSetContent = (value: string, pathStack: number[]) => {
+    const newRoot = deepCopyTree(periNoteData.answerThree);
+    const current = getTargetNodeByPath(newRoot, pathStack);
+
+    current.content = value;
+
+    setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
+  };
+
+  const handleDeleteChild = (pathStack: number[]) => {
+    const newRoot = deepCopyTree(periNoteData.answerThree);
+    // 삭제할 때는 자신의 부모를 찾아서 children을 제거
+    const parent = getTargetNodeByPath(newRoot, pathStack.slice(0, -1));
+
+    // parent.children.splice(pathStack[pathStack.length - 1], 1);
+    parent.children[pathStack[pathStack.length - 1]] = {
+      ...parent.children[pathStack[pathStack.length - 1]],
+      type: "deleted",
+    };
+
+    setPeriNoteData((current) => ({ ...current, answerThree: newRoot }));
+  };
+
   return {
     periNoteData,
     isPerNoteLoading: periNoteLoadable.state === "loading",
-    setPeriNoteData,
     savePeriNote,
     completePeriNote,
+    handleAddChildAnswer,
+    handleAddSiblingAnswer,
+    handleAddChildQuestion,
+    handleAddSiblingQuestion,
+    handleSetContent,
+    handleDeleteChild,
   };
 }


### PR DESCRIPTION
## 📌 나 이런 거 했어요

<!-- 구현 기능 명세서 ~ 소요 시간 등등 -->

- [🔗 QA 1](https://www.notion.so/life-racer/ccbb4d87f5174a7db0519d54b709efcd)
- [🔗 QA 2](https://www.notion.so/life-racer/d7de653ffff84ea5aac80a96d4b6ee4b)
- [🔗 QA 3](https://www.notion.so/life-racer/99f91bed125143888582a170d9f9d900)
- 비즈니스 로직 모두 커스텀 훅 안으로 분리

<br />

## 📌 나 이런 거 알게 되었어요

<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->

- 꼬리질문 담당 QANode 에는 
  - 본인 바로 옆 질문 추가
  - 맨 아래 질문 추가
  - 본인 바로 옆 답변 추가
  - 맨 아래 답변 추가
  
  다 있더라구요 :))^.. 인자 늘어나는 꼴 못보겠어서 함수 다 분리해서 props 로 넘겨줬습니다


