### PR TITLE
Feature/signup kkm

### DIFF
--- a/components/signup/SignupForm.tsx
+++ b/components/signup/SignupForm.tsx
@@ -6,6 +6,7 @@ import LocalStorage from "../../core/localStorage";
 import { IcSignupChecking } from "../../public/assets/icons";
 import { UseFormDataType } from "../../types/signup";
 import { errorPatterns } from "../../util/check";
+import referralLinkLIst from "../../util/referralLinkList";
 import { AlertLabel } from "../common";
 import { DefaultButton } from "../common/styled/Button";
 import { Input } from "../common/styled/Input";
@@ -35,10 +36,14 @@ export default function SignupForm(props: SignupFormProps) {
     </>
   );
 
+  const linkOfCondition = referralLinkLIst[0].href;
+
   const AgreeConditionBox = (
     <StAgreeConditionBox htmlFor="signupAgree" onClick={onToggleIsAgreeCondition}>
       <StIcSignupChecking isagree={isAgree} />
-      <p>개인정보 수집 및 이용 약관에 동의합니다.</p>
+      <a href={linkOfCondition} target="_blank" rel="noopener noreferrer">
+        개인정보 수집 및 이용 약관에 동의합니다.
+      </a>
     </StAgreeConditionBox>
   );
 
@@ -54,7 +59,7 @@ export default function SignupForm(props: SignupFormProps) {
 
       {keyIndex === "email" && AgreeConditionBox}
 
-      <StNextStepBtn disabled={!isDirty} type="submit">
+      <StNextStepBtn disabled={!isDirty || !isAgree} type="submit">
         다음 계단
       </StNextStepBtn>
     </>
@@ -86,6 +91,10 @@ const StAgreeConditionBox = styled.label`
   align-items: center;
 
   margin: 1.7rem 0 0 0;
+
+  & > a {
+    text-decoration: underline;
+  }
 
   ${({ theme }) => theme.fonts.body6}
 `;

--- a/components/signup/SignupForm.tsx
+++ b/components/signup/SignupForm.tsx
@@ -26,6 +26,8 @@ interface SignupFormProps {
 export default function SignupForm(props: SignupFormProps) {
   const { register, errors, keyData, keyIndex, isAgree, isDirty, onToggleIsAgreeCondition } = props;
 
+  const linkOfCondition = referralLinkLIst[0].href;
+
   const PasswordForm = (
     <>
       <StEmailFixed>{LocalStorage.getItem("booktez-email")}</StEmailFixed>
@@ -36,11 +38,9 @@ export default function SignupForm(props: SignupFormProps) {
     </>
   );
 
-  const linkOfCondition = referralLinkLIst[0].href;
-
   const AgreeConditionBox = (
-    <StAgreeConditionBox htmlFor="signupAgree" onClick={onToggleIsAgreeCondition}>
-      <StIcSignupChecking isagree={isAgree} />
+    <StAgreeConditionBox htmlFor="signupAgree">
+      <StIcSignupChecking isagree={isAgree} onClick={onToggleIsAgreeCondition} />
       <a href={linkOfCondition} target="_blank" rel="noopener noreferrer">
         개인정보 수집 및 이용 약관에 동의합니다.
       </a>
@@ -56,9 +56,7 @@ export default function SignupForm(props: SignupFormProps) {
         <Input {...register(keyIndex, errorPatterns[keyIndex])} placeholder={`${keyData[keyIndex]}을 입력해 주세요`} />
       )}
       {errors[keyIndex]?.message && <AlertLabel message={errors[keyIndex].message} />}
-
       {keyIndex === "email" && AgreeConditionBox}
-
       <StNextStepBtn disabled={!isDirty || !isAgree} type="submit">
         다음 계단
       </StNextStepBtn>

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -12,7 +12,7 @@
 import styled from "@emotion/styled";
 import { AnimatePresence, motion } from "framer-motion";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { NavHeader } from "../../components/common";
@@ -99,12 +99,9 @@ export default function Signup() {
 
     setValue(formDataKeyIndex, "", { shouldDirty: true });
   };
-
   // 폼 제출 에러가 없는지 확인
   const submitForm = async (loginFormData: UseFormDataType) => {
     const inputValue = loginFormData[formDataKeyIndex];
-
-    console.log(inputValue);
 
     // 비밀번호 입력까지 마치면 자동 로그인
     if (formDataKeyIndex === "password") {
@@ -137,6 +134,21 @@ export default function Signup() {
   const handleToggleIsAgreeCondition = () => {
     setIsAgreeCondition(!isAgreeCondition);
   };
+
+  useEffect(() => {
+    if (formDataKeyIndex == "nickname" || formDataKeyIndex == "password") {
+      const prevFormDataKeyIndex = formDataKeyIndex == "password" ? "nickname" : "email";
+
+      history.pushState(null, "", "");
+      window.onpopstate = () => {
+        setFormDataKeyIndex(prevFormDataKeyIndex);
+      };
+    } else {
+      window.onpopstate = () => {
+        // 초기화
+      };
+    }
+  }, [setFormDataKeyIndex]);
 
   return (
     <>

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -112,25 +112,17 @@ export default function Signup() {
         setError("password", { type: "server", message: "비밀번호가 일치하지 않습니다." });
       }
     } else {
-      // 이메일 입력시 개인정보 취급 방침 동의를 먼저 유도
-      if (formDataKeyIndex === "email" && !isAgreeCondition) {
-        setError(formDataKeyIndex, {
-          type: "agreeCondition",
-          message: "개인정보 수집 및 이용 약관에 동의해주시기 바랍니다.",
-        });
-      } else {
-        // 서버로 데이터를 보내서 유효성 검사
-        // return: 유효한지(isValid) && 에러 메시지(message)
-        const { isValid, message } = await checkIsValid(formDataKeyIndex, key);
+      // 서버로 데이터를 보내서 유효성 검사
+      // return: 유효한지(isValid) && 에러 메시지(message)
+      const { isValid, message } = await checkIsValid(formDataKeyIndex, key);
 
-        if (isValid) {
-          setNextStep(key);
-          if (formDataKeyIndex === "email") {
-            LocalStorage.setItem("booktez-email", loginFormData["email"]);
-          }
-        } else {
-          setError(formDataKeyIndex, { type: "server", message });
+      if (isValid) {
+        setNextStep(key);
+        if (formDataKeyIndex === "email") {
+          LocalStorage.setItem("booktez-email", loginFormData["email"]);
         }
+      } else {
+        setError(formDataKeyIndex, { type: "server", message });
       }
     }
   };

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -154,7 +154,13 @@ export default function Signup() {
             <StFormWrapper>
               <StSignupImage src={imgList[formDataKeyIndex]} alt="회원가입 첫 단계" />
               <StSignupHeading2>나만의 서재를 만드는 중이에요!</StSignupHeading2>
-              <StSignupParagraph>당신의 {formDataKeyData[formDataKeyIndex]}을 입력해 주세요.</StSignupParagraph>
+
+              {formDataKeyData[formDataKeyIndex] == "닉네임" ? (
+                <StSignupParagraph>제가 여러분을 어떻게 부르면 될까요?</StSignupParagraph>
+              ) : (
+                <StSignupParagraph>당신의 {formDataKeyData[formDataKeyIndex]}을 입력해 주세요.</StSignupParagraph>
+              )}
+
               <StForm onSubmit={handleSubmit(submitForm)}>
                 <SignupForm
                   register={register}

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -78,13 +78,13 @@ export default function Signup() {
   };
 
   // 다음 단계로 이동하는 함수
-  const setNextStep = (key: string) => {
+  const setNextStep = (inputValue: string) => {
     setUserData((current) => {
-      const formData = { ...current };
+      const userData = { ...current };
 
-      formData[formDataKeyIndex] = key;
+      userData[formDataKeyIndex] = inputValue;
 
-      return formData;
+      return userData;
     });
 
     setFormDataKeyIndex((current) => {
@@ -97,34 +97,41 @@ export default function Signup() {
       return "submit";
     });
 
-    setValue(formDataKeyIndex, "");
+    setValue(formDataKeyIndex, "", { shouldDirty: true });
   };
 
   // 폼 제출 에러가 없는지 확인
   const submitForm = async (loginFormData: UseFormDataType) => {
-    const key = loginFormData[formDataKeyIndex];
+    const inputValue = loginFormData[formDataKeyIndex];
+
+    console.log(inputValue);
 
     // 비밀번호 입력까지 마치면 자동 로그인
     if (formDataKeyIndex === "password") {
       if (loginFormData["password"] === loginFormData["password2"]) {
-        autoLoginAfterSignup(key);
-      } else {
-        setError("password", { type: "server", message: "비밀번호가 일치하지 않습니다." });
-      }
-    } else {
-      // 서버로 데이터를 보내서 유효성 검사
-      // return: 유효한지(isValid) && 에러 메시지(message)
-      const { isValid, message } = await checkIsValid(formDataKeyIndex, key);
+        autoLoginAfterSignup(inputValue);
 
-      if (isValid) {
-        setNextStep(key);
-        if (formDataKeyIndex === "email") {
-          LocalStorage.setItem("booktez-email", loginFormData["email"]);
-        }
-      } else {
-        setError(formDataKeyIndex, { type: "server", message });
+        return;
       }
+      setError("password", { type: "server", message: "비밀번호가 일치하지 않습니다." });
+
+      return;
     }
+
+    // 서버로 데이터를 보내서 유효성 검사
+    // return: 유효한지(isValid) && 에러 메시지(message)
+    const { isValid, message } = await checkIsValid(formDataKeyIndex, inputValue);
+
+    if (isValid) {
+      setNextStep(inputValue);
+
+      if (formDataKeyIndex === "email") {
+        LocalStorage.setItem("booktez-email", loginFormData["email"]);
+      }
+
+      return;
+    }
+    setError(formDataKeyIndex, { type: "server", message });
   };
 
   const handleToggleIsAgreeCondition = () => {

--- a/util/check.ts
+++ b/util/check.ts
@@ -1,6 +1,8 @@
 const EMAIL_REGEX =
   /^(([^<>()\].,;:\s@"]+(\.[^<>()\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
 
+const NICKNAME_REGEX = /^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,10}$/i;
+
 const INVALID_PWD_CHAR_LIST: { [key: string]: string } = {
   ",": "반점(,)",
   '"': '쌍따옴표(")',
@@ -33,6 +35,10 @@ const nicknameErrorPatterns: ErrorCondition = {
   required: {
     value: true,
     message: "닉네임을 입력해주세요.",
+  },
+  pattern: {
+    value: NICKNAME_REGEX,
+    message: "2-10자 이내의 영문/한글/숫자로 입력해주세요.",
   },
 };
 


### PR DESCRIPTION
## 📌 나 이런 거 했어요
- [x] [회원가입 1단계]\
밑줄 + 링크를 추가하였고, 약관 체크를 하지 않았다면 '다음 계단'을 비활성화 상태로 만들어주었습니다.
- [x]  [회원가입 2단계]\
2단계로 넘어온 직후에는 아무것도 입력되어있지 않기 때문에 '다음 계단'을 비활성화 상태로 만들어주었습니다.
- [x]  [회원가입 2단계]\
#이나 & 같은 특수문자가 허용되고 있었는데, 닉네임 로직에서는 서버에서 유효성 검사를 해주고 있었습니다. 
서버 측에서 수정처리를 해주는 것도 좋겠지만, 유효성 검사 자체는 클라이언트와 서버 양 측에서 모두 해주는 것이 좋다고도 
알고 있어서 정규식 추가 검사를 해주었습니다.
- [x] [회원가입 2단계]\
문구를 변경하였습니다.
- [ ] [회원가입 3단계]\
비밀번호 입력 화면 문구 수정 예정
- [x] [회원가입 전체]\
회원 가입 화면에서 뒤로 가기 시 새로고침 되는 상태에서 이전 단계 화면(실제로는 컴포넌트만 변경)으로 이동하도록 하였습니다.
<br />

## 📌 나 이런 거 알게 되었어요

<!-- 새롭게 알게 된 부분을 적쟈 (기록하면서 개발하기!) -->

- useForm의 setValue 옵션에서 shouldDefault 값으로 isDirty 값을 변경해줄 수 있는 것을 알게 되었습니다.

<br />

## 📌 나 이런 거 궁금해요

- 메인 페이지 좌측 배너에서 회원가입에 들어가는 경우 살짝 튀는 현상(렌더링 깜빡)이 발생하는 것 같은데 추후 확인이 필요할 것 같습니다.
